### PR TITLE
JCN-185-log-en-metodos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Logs in write methods (insert, multiInsert, update, save, multiSave, remove and multiRemove)
+- Logs for write methods: 
+	- insert
+	- multiInsert
+	- update
+	- save
+	- multiSave
+	- remove
+	- multiRemove
+- `@janiscommerce/log` package
+- `lib/utils.js` module
 
 ## [3.1.0] - 2019-10-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Logs in write methods (insert, multiInsert, update, save, multiSave, remove and multiRemove)
+
 ## [3.1.0] - 2019-10-09
 ### Fixed
 - Tests typo fix

--- a/lib/model.js
+++ b/lib/model.js
@@ -99,7 +99,7 @@ class Model {
 		if(!this.session)
 			return;
 
-		if(this._isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog)) // eslint-disable-line
+		if(this._isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog))
 			log = omitRecursive(log, this.constructor.excludeFieldsInLog);
 
 		Log.add(this.session.clientCode, {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const DatabaseDispatcher = require('@janiscommerce/database-dispatcher');
+const Log = require('@janiscommerce/log');
 
 const ModelError = require('./model-error');
+
+const { titleCaseToDashCase, omitRecursive } = require('./utils');
 
 const DEFAULT_PAGE_LIMIT = 500;
 
@@ -83,6 +86,31 @@ class Model {
 		return params.changeKeys ? this.constructor.changeKeys(newItems, params.changeKeys) : newItems;
 	}
 
+	_isObject(object) {
+
+		if(object === null || typeof object !== 'object' || Array.isArray(object))
+			return false;
+
+		return true;
+	}
+
+	_saveLog(entityId, type, message, log) {
+
+		if(!this.session)
+			return;
+
+		if(this._isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog)) // eslint-disable-line
+			log = omitRecursive(log, this.constructor.excludeFieldsInLog);
+
+		Log.add(this.session.clientCode, {
+			type,
+			entity: titleCaseToDashCase(this.constructor.name),
+			...entityId ? { entityId } : {},
+			message,
+			log
+		});
+	}
+
 	/**
 	 * Get Paged database data
 	 *
@@ -124,45 +152,102 @@ class Model {
 	}
 
 	async insert(item) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.insert(this, item);
+		const result = await db.insert(this, item);
+
+		this._saveLog(result, 'inserted', 'Inserted document', item);
+
+		return result;
 	}
 
 	async save(item) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.save(this, item);
+		const result = await db.save(this, item);
+
+		this._saveLog(result, 'upserted', 'Upserted document', item);
+
+		return result;
 	}
 
 	async update(values, filter) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.update(this, values, filter);
+		const result = await db.update(this, values, filter);
+
+		if(this._isObject(filter))
+			this._saveLog(filter.id, 'updated', 'Updated documents', { values, filter });
+
+		return result;
 	}
 
 	async remove(item) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.remove(this, item);
+		const result = await db.remove(this, item);
+
+		if(this._isObject(item))
+			this._saveLog(item.id, 'removed', 'Removed document', item);
+
+		return result;
 	}
 
 	async multiInsert(items) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.multiInsert(this, items);
+		const result = await db.multiInsert(this, items);
+
+		if(Array.isArray(items)) {
+
+			items.forEach(item => {
+				this._saveLog(null, 'inserted', 'Inserted document', item);
+			});
+		}
+
+		return result;
 	}
 
 	async multiSave(items) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.multiSave(this, items);
+		const result = await db.multiSave(this, items);
+
+		if(Array.isArray(items)) {
+
+			items.forEach(item => {
+
+				if(this._isObject(item))
+					this._saveLog(item.id, 'upserted', 'Upserted document', item);
+			});
+		}
+
+		return result;
 	}
 
 	async multiRemove(filter) {
+
 		this.useReadDB = false;
+
 		const db = await this.getDb();
-		return db.multiRemove(this, filter);
+		const result = await db.multiRemove(this, filter);
+
+		if(this._isObject(filter))
+			this._saveLog(filter.id, 'removed', 'Removed documents', filter);
+
+		return result;
 	}
 
 	/**

--- a/lib/model.js
+++ b/lib/model.js
@@ -5,7 +5,7 @@ const Log = require('@janiscommerce/log');
 
 const ModelError = require('./model-error');
 
-const { titleCaseToDashCase, omitRecursive } = require('./utils');
+const { titleCaseToDashCase, omitRecursive, isObject } = require('./utils');
 
 const DEFAULT_PAGE_LIMIT = 500;
 
@@ -86,31 +86,6 @@ class Model {
 		return params.changeKeys ? this.constructor.changeKeys(newItems, params.changeKeys) : newItems;
 	}
 
-	_isObject(object) {
-
-		if(object === null || typeof object !== 'object' || Array.isArray(object))
-			return false;
-
-		return true;
-	}
-
-	_saveLog(entityId, type, message, log) {
-
-		if(!this.session)
-			return;
-
-		if(this._isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog))
-			log = omitRecursive(log, this.constructor.excludeFieldsInLog);
-
-		Log.add(this.session.clientCode, {
-			type,
-			entity: titleCaseToDashCase(this.constructor.name),
-			...entityId ? { entityId } : {},
-			message,
-			log
-		});
-	}
-
 	/**
 	 * Get Paged database data
 	 *
@@ -158,7 +133,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.insert(this, item);
 
-		this._saveLog(result, 'inserted', 'Inserted document', item);
+		this._saveLog(result, 'inserted', item);
 
 		return result;
 	}
@@ -170,7 +145,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.save(this, item);
 
-		this._saveLog(result, 'upserted', 'Upserted document', item);
+		this._saveLog(result, 'upserted', item);
 
 		return result;
 	}
@@ -182,8 +157,8 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.update(this, values, filter);
 
-		if(this._isObject(filter))
-			this._saveLog(filter.id, 'updated', 'Updated documents', { values, filter });
+		if(isObject(filter))
+			this._saveLog(filter.id, 'updated', { values, filter });
 
 		return result;
 	}
@@ -195,8 +170,8 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.remove(this, item);
 
-		if(this._isObject(item))
-			this._saveLog(item.id, 'removed', 'Removed document', item);
+		if(isObject(item))
+			this._saveLog(item.id, 'removed', item);
 
 		return result;
 	}
@@ -211,7 +186,7 @@ class Model {
 		if(Array.isArray(items)) {
 
 			items.forEach(item => {
-				this._saveLog(null, 'inserted', 'Inserted document', item);
+				this._saveLog(null, 'inserted', item);
 			});
 		}
 
@@ -229,8 +204,8 @@ class Model {
 
 			items.forEach(item => {
 
-				if(this._isObject(item))
-					this._saveLog(item.id, 'upserted', 'Upserted document', item);
+				if(isObject(item))
+					this._saveLog(item.id, 'upserted', item);
 			});
 		}
 
@@ -244,8 +219,8 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.multiRemove(this, filter);
 
-		if(this._isObject(filter))
-			this._saveLog(filter.id, 'removed', 'Removed documents', filter);
+		if(isObject(filter))
+			this._saveLog(filter.id, 'removed', filter);
 
 		return result;
 	}
@@ -271,6 +246,28 @@ class Model {
 		});
 
 		return newItems;
+	}
+
+	/**
+	 * Creates a log with the specified parameters
+	 * @param {String} entityId The entityId that will be included in the log
+	 * @param {String} type The log type
+	 * @param {Object} log The log object with detailed information such as received filters or items
+	 */
+	_saveLog(entityId, type, log) {
+
+		if(!this.session)
+			return;
+
+		if(isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog))
+			log = omitRecursive(log, this.constructor.excludeFieldsInLog);
+
+		Log.add(this.session.clientCode, {
+			type,
+			entity: titleCaseToDashCase(this.constructor.name),
+			...entityId ? { entityId } : {},
+			log
+		});
 	}
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -133,7 +133,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.insert(this, item);
 
-		this._saveLog(result, 'inserted', item);
+		this._saveLog('inserted', item, result);
 
 		return result;
 	}
@@ -145,7 +145,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.save(this, item);
 
-		this._saveLog(result, 'upserted', item);
+		this._saveLog('upserted', item, result);
 
 		return result;
 	}
@@ -158,7 +158,7 @@ class Model {
 		const result = await db.update(this, values, filter);
 
 		if(isObject(filter))
-			this._saveLog(filter.id, 'updated', { values, filter });
+			this._saveLog('updated', { values, filter }, filter.id);
 
 		return result;
 	}
@@ -171,7 +171,7 @@ class Model {
 		const result = await db.remove(this, item);
 
 		if(isObject(item))
-			this._saveLog(item.id, 'removed', item);
+			this._saveLog('removed', item, item.id);
 
 		return result;
 	}
@@ -186,7 +186,7 @@ class Model {
 		if(Array.isArray(items)) {
 
 			items.forEach(item => {
-				this._saveLog(null, 'inserted', item);
+				this._saveLog('inserted', item);
 			});
 		}
 
@@ -205,7 +205,7 @@ class Model {
 			items.forEach(item => {
 
 				if(isObject(item))
-					this._saveLog(item.id, 'upserted', item);
+					this._saveLog('upserted', item, item.id);
 			});
 		}
 
@@ -220,7 +220,7 @@ class Model {
 		const result = await db.multiRemove(this, filter);
 
 		if(isObject(filter))
-			this._saveLog(filter.id, 'removed', filter);
+			this._saveLog('removed', filter, filter.id);
 
 		return result;
 	}
@@ -250,11 +250,11 @@ class Model {
 
 	/**
 	 * Creates a log with the specified parameters
-	 * @param {String} entityId The entityId that will be included in the log
 	 * @param {String} type The log type
 	 * @param {Object} log The log object with detailed information such as received filters or items
+	 * @param {String} entityId The entityId that will be included in the log
 	 */
-	_saveLog(entityId, type, log) {
+	_saveLog(type, log, entityId) {
 
 		if(!this.session)
 			return;
@@ -262,12 +262,16 @@ class Model {
 		if(isObject(log) && Array.isArray(this.constructor.excludeFieldsInLog))
 			log = omitRecursive(log, this.constructor.excludeFieldsInLog);
 
-		Log.add(this.session.clientCode, {
-			type,
+		const builtLog = {
 			entity: titleCaseToDashCase(this.constructor.name),
-			...entityId ? { entityId } : {},
+			type,
 			log
-		});
+		};
+
+		if(typeof entityId !== 'undefined')
+			builtLog.entityId = entityId;
+
+		Log.add(this.session.clientCode, builtLog);
 	}
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,16 @@ const titleCaseToDashCase = string => {
 		.replace(/^-/, '');
 };
 
+const isObject = object => {
+
+	if(object === null || typeof object !== 'object' || Array.isArray(object))
+		return false;
+
+	return true;
+};
+
 module.exports = {
 	omitRecursive,
-	titleCaseToDashCase
+	titleCaseToDashCase,
+	isObject
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const omit = require('lodash.omit');
+
+const omitRecursive = (object, exclude) => {
+
+	object = { ...object }; // Avoid original object modification
+
+	Object.entries(object).forEach(([key, value]) => {
+		object[key] = typeof value === 'object' && !Array.isArray(value) ? omitRecursive(value, exclude) : value;
+	});
+
+	return omit(object, exclude);
+};
+
+const titleCaseToDashCase = string => {
+	return string
+		.replace(/([A-Z])/g, match => `-${match[0].toLowerCase()}`)
+		.replace(/^-/, '');
+};
+
+module.exports = {
+	omitRecursive,
+	titleCaseToDashCase
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/model",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -134,6 +134,15 @@
       "requires": {
         "@janiscommerce/settings": "^1.0.1",
         "md5": "^2.2.1"
+      }
+    },
+    "@janiscommerce/log": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@janiscommerce/log/-/log-1.2.0.tgz",
+      "integrity": "sha512-u7yukvqGAScGsRYyKKifCdDEQbdlM2F9LRQakZjuuV1NjXE/ttMwLWzZDOAjAN4HxNaRMydkyFNI5E7USxtgPg==",
+      "requires": {
+        "aws-sdk": "^2.498.0",
+        "uuid": "^3.3.2"
       }
     },
     "@janiscommerce/settings": {
@@ -274,11 +283,32 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "aws-sdk": {
+      "version": "2.564.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.564.0.tgz",
+      "integrity": "sha512-X5MbcebjQ3iPNBvZ27WZyMEVCleBLqot2hqVz2M9XvMDR4B8qqPuteWrtbLu+DVjENvVD7Oj0BOIjrYEVWacFA==",
+      "requires": {
+        "buffer": "^4.9.1",
+        "events": "^1.1.1",
+        "ieee754": "^1.1.13",
+        "jmespath": "^0.15.0",
+        "querystring": "^0.2.0",
+        "sax": "^1.2.1",
+        "url": "^0.10.3",
+        "uuid": "^3.3.2",
+        "xml2js": "^0.4.19"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -295,6 +325,16 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
     },
     "caching-transform": {
       "version": "3.0.2",
@@ -595,7 +635,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -643,7 +682,6 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
       "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -661,7 +699,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -907,6 +944,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -1091,8 +1133,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1177,7 +1218,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1191,8 +1231,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "hasha": {
       "version": "3.0.0",
@@ -1356,6 +1395,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1446,8 +1490,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -1461,8 +1504,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-directory": {
       "version": "0.3.1",
@@ -1486,7 +1528,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -1501,7 +1542,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -1509,8 +1549,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1608,6 +1647,11 @@
         "handlebars": "^4.1.2"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1703,6 +1747,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
     },
     "lolex": {
       "version": "4.2.0",
@@ -2005,14 +2054,12 @@
     "object-inspect": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-      "dev": true
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -2036,6 +2083,15 @@
         "es-abstract": "^1.12.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
@@ -2286,6 +2342,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "read-pkg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2403,6 +2464,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.7.1",
@@ -2547,7 +2613,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -2557,7 +2622,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -2850,11 +2914,35 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "dev": true
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -2951,6 +3039,21 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "xml2js": {
+      "version": "0.4.22",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
+      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "util.promisify": "~1.0.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "test": "tests"
   },
   "dependencies": {
-    "@janiscommerce/database-dispatcher": "^2.0.0"
+    "@janiscommerce/database-dispatcher": "^2.0.0",
+    "@janiscommerce/log": "^1.2.0",
+    "lodash.omit": "^4.5.0"
   }
 }

--- a/tests/model-test.js
+++ b/tests/model-test.js
@@ -513,13 +513,6 @@ describe('Model', () => {
 				});
 			});
 
-			it('Should not log if multiInsert method does not receive items', async () => {
-
-				DBDriver.multiInsert.returns();
-				await myClientModel.multiInsert();
-				sandbox.assert.notCalled(Log.add);
-			});
-
 			it('Should log the update operation', async () => {
 
 				DBDriver.update.returns(1);
@@ -538,13 +531,6 @@ describe('Model', () => {
 				});
 			});
 
-			it('Should not log if the update method does not receive filters', async () => {
-
-				DBDriver.update.returns(1);
-				await myClientModel.update({ some: 'data' });
-				sandbox.assert.notCalled(Log.add);
-			});
-
 			it('Should log the remove operation', async () => {
 
 				DBDriver.remove.returns('some-id');
@@ -560,13 +546,6 @@ describe('Model', () => {
 				});
 			});
 
-			it('Should not log if remove method does not receive an item', async () => {
-
-				DBDriver.remove.returns();
-				await myClientModel.remove();
-				sandbox.assert.notCalled(Log.add);
-			});
-
 			it('Should log the multiRemove operation', async () => {
 
 				DBDriver.multiRemove.returns('some-id');
@@ -580,13 +559,6 @@ describe('Model', () => {
 					message: 'Removed documents',
 					log: { id: 'some-id' }
 				});
-			});
-
-			it('Should not log if multiRemove method does not receive filters', async () => {
-
-				DBDriver.multiRemove.returns();
-				await myClientModel.multiRemove();
-				sandbox.assert.notCalled(Log.add);
 			});
 
 			it('Should log the save operation', async () => {
@@ -619,14 +591,7 @@ describe('Model', () => {
 				});
 			});
 
-			it('Should not log if multiSave method does not receive items', async () => {
-
-				DBDriver.multiSave.returns();
-				await myClientModel.multiSave();
-				sandbox.assert.notCalled(Log.add);
-			});
-
-			it('Should not log the invalid entries if multiSave method receives invalid items', async () => {
+			it('Shouldn\'t log the invalid entries if multiSave method receives invalid items', async () => {
 
 				DBDriver.multiSave.returns();
 				await myClientModel.multiSave([{ id: 'some-id' }, null]);
@@ -638,6 +603,23 @@ describe('Model', () => {
 					entityId: 'some-id',
 					message: 'Upserted document',
 					log: { id: 'some-id' }
+				});
+			});
+
+			[
+				'update',
+				'remove',
+				'multiSave',
+				'multiInsert',
+				'multiRemove'
+
+			].forEach(method => {
+
+				it(`Shouldn't log if ${method} does not receive items/filters`, async () => {
+
+					DBDriver[method].returns();
+					await myClientModel[method]();
+					sandbox.assert.notCalled(Log.add);
 				});
 			});
 		});

--- a/tests/model-test.js
+++ b/tests/model-test.js
@@ -494,7 +494,6 @@ describe('Model', () => {
 					type: 'inserted',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Inserted document',
 					log: { some: 'data' }
 				});
 			});
@@ -508,7 +507,6 @@ describe('Model', () => {
 				sandbox.assert.calledWithExactly(Log.add, 'some-client', {
 					type: 'inserted',
 					entity: 'client-model',
-					message: 'Inserted document',
 					log: { some: 'data' }
 				});
 			});
@@ -523,7 +521,6 @@ describe('Model', () => {
 					type: 'updated',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Updated documents',
 					log: {
 						values: { some: 'data' },
 						filter: { id: 'some-id' }
@@ -541,7 +538,6 @@ describe('Model', () => {
 					type: 'removed',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Removed document',
 					log: { id: 'some-id', some: 'data' }
 				});
 			});
@@ -556,7 +552,6 @@ describe('Model', () => {
 					type: 'removed',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Removed documents',
 					log: { id: 'some-id' }
 				});
 			});
@@ -571,7 +566,6 @@ describe('Model', () => {
 					type: 'upserted',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Upserted document',
 					log: { id: 'some-id', some: 'data' }
 				});
 			});
@@ -586,7 +580,6 @@ describe('Model', () => {
 					type: 'upserted',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Upserted document',
 					log: { id: 'some-id', some: 'data' }
 				});
 			});
@@ -601,7 +594,6 @@ describe('Model', () => {
 					type: 'upserted',
 					entity: 'client-model',
 					entityId: 'some-id',
-					message: 'Upserted document',
 					log: { id: 'some-id' }
 				});
 			});
@@ -651,7 +643,6 @@ describe('Model', () => {
 				type: 'inserted',
 				entity: 'client-model',
 				entityId: 'some-id',
-				message: 'Inserted document',
 				log: {
 					username: 'some-username',
 					location: {


### PR DESCRIPTION
**JCN-185-LOG-EN-METODOS**
JCN-185 Agregar log al llamar los metodos de modificaciones

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-185

**DESCRIPCIÓN DEL REQUERIMIENTO**
**1.1.** Se deben guardar logs para el método insert con el type inserted
**1.1.1.** El dato entityId se debe obtener leyendo la respuesta del DBDriver. 
**1.1.2.** En el dato log se deben guardar los datos a insertar.
**1.2.** Se deben guardar logs para el método update con el type updated
**1.2.1.** El dato entityId se debe obtener buscándolo en el parámetro filter, en caso de no encontrarlo, guardar el log de todas formas.
**1.2.2.** En el dato log se deben guardar los datos a actualizar y los filtros.
**1.3.** Se deben guardar logs para el método remove y multiRemovecon el type removed
**1.3.1.** El dato entityId se debe obtener buscándolo en el parámetro filter, en caso de no encontrarlo, guardar el log de todas formas.
**1.3.2.** En el dato log se deben guardar los filtros para eliminar.
**1.4.** Se deben guardar logs para el método save con el type upserted
**1.4.1.** El dato entityId se debe obtener leyendo la respuesta del DBDriver. 
**1.4.2.** En el dato log se deben guardar los datos a insertar o actualizar.
**1.5.** Se deben guardar logs para el método multiSave para los items que se envie el dato id, el mismo se debe usar como entityId, cada item debe dejar un log individual con el type upserted
**1.6.** En todos los casos, el dato entity se debe obtener con el name del Model actual. 
**1.7.** Se debe poder configurar en los modelos, un listado de campos para excluir de los logs.
**1.7.1.** Los campos del getter deben ser eliminados del log para no exponer datos sensibles.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados