### PR TITLE
finish fix. Add an await to getPaged

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -133,7 +133,7 @@ class Model {
 		newParams.page++;
 
 		if(items.length === newParams.limit)
-			this.getPaged(newParams, callback);
+			await this.getPaged(newParams, callback);
 	}
 
 	async getTotals() {


### PR DESCRIPTION
**Link al ticket**
https://fizzmod.atlassian.net/browse/JAN-774

**Descripción del requerimiento**
Se requiere corregir el metodo getPaged para que espere el siguiente llamado.

**Descripción de la solución**
Se agrego un await al llamarse a si mismo el metodo

Cómo se puede probar?
Se debe hacer un getPaged que sobrepase el limite de documentos, y ver que se recorran la totalidad de los documentos

Screenshots
No.

Necesita deployear queries?
No.

Datos extra a tener en cuenta
No.

Changelog
Fixed: await for inside call on getPaged method