### PR TITLE
JCN 220 agregar status getter set on insert map id reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - `statuses` getter
+- `setOnInsert` parameter in `save` and `multiSave` methods
 
 ## [3.5.0] - 2020-01-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `statuses` getter
+
 ## [3.5.0] - 2020-01-13
 ### Added
 - `getBy()` alias added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `statuses` getter
 - `setOnInsert` parameter in `save` and `multiSave` methods
+- `mapIdByReferenceId` method
 
 ## [3.5.0] - 2020-01-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ You can add database connection settings by adding the field names from the rece
 * **excludeFieldsInLog** (*getter*).
 Returns the fields that will be removed from the logs as an array of strings. For example: `['password', 'super-secret']`
 
+* **statuses** (*class getter*).
+Returns an `object` with the default statuses (`active` / `inactive`)
+
+```js
+console.log(Model.statuses);
+
+/*
+	{
+		active: 'active',
+		inactive: 'inactive'
+	}
+*/
+```
+
 ### const items = await myModel.get(params)
 
 - Returns items from database

--- a/README.md
+++ b/README.md
@@ -235,12 +235,13 @@ const items = await myModel.get({ filters: { foo: 'bar' }});
 
 ```
 
-### myModel.save(item)
+### myModel.save(item, setOnInsert)
 
 - Inserts/updates an item in DB. This method will perfrom an upsert.
+- `setOnInsert` to add default values on Insert, optional
 
 ```js
-await myModel.save({ foo: 'bar' });
+await myModel.save({ foo: 'bar' }, { status: 'active' });
 
 const items = await myModel.get({ filters: { foo: 'bar' }});
 
@@ -248,7 +249,8 @@ const items = await myModel.get({ filters: { foo: 'bar' }});
 	items content:
 	[
 		{
-			foo: 'bar'
+			foo: 'bar',
+			status: 'active'
 		}
 		//...
 	]
@@ -301,20 +303,21 @@ const items = await myModel.get();
 ```
 
 
-### myModel.multiSave(items)
+### myModel.multiSave(items, setOnInsert)
 
 - Perform a bulk save of items in DB. This action will insert/update (upsert) elements.
+- `setOnInsert` to add default values on Insert, optional
 
 ```js
-await myModel.multiSave([{ foo: 1 }, { foo: 2 }]);
+await myModel.multiSave([{ foo: 1 }, { foo: 2, status: 'pending' }], { status: 'active' });
 
 const items = await myModel.get();
 
 /**
 	items content:
 	[
-		{ foo: 1 },
-		{ foo: 2 }
+		{ foo: 1, status: 'active' },
+		{ foo: 2, status: 'pending' }
 	]
 */
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,25 @@ const totals = await myModel.getTotals();
 
 ```
 
+### myModel.mapIdByReferenceId(referencesIds)
+
+- Search all References Ids and return an Object with key: `referenceIds` and values: `id`, only those founds.
+- **referencesIds**: `Array<strings>` List of References Ids
+
+
+```js
+
+await myModel.mapIdByReferenceId(['some-ref-id', 'other-ref-id', 'foo-ref-id']);
+
+/**
+	{
+		some-ref-id: 'some-id',
+		foo-ref-id: 'foo-id'
+	}
+*/
+
+```
+
 ### const uniqueValues = await myModel.distinct(key, params)
 
 - Returns unique values of the key field from database

--- a/lib/model.js
+++ b/lib/model.js
@@ -226,6 +226,20 @@ class Model {
 		return db.getTotals(this);
 	}
 
+	async mapIdByReferenceId(referencesIds) {
+
+		if(!Array.isArray(referencesIds))
+			throw new ModelError('References Ids must be an Array', ModelError.codes.INVALID_VALUE);
+
+		const items = await this.getBy('referenceId', referencesIds);
+
+		return items
+			.filter(item => referencesIds.includes(item.referenceId))
+			.reduce((acum, { referenceId, id }) => {
+				return { ...acum, [referenceId]: id.toString() };
+			}, {});
+	}
+
 	async insert(item) {
 
 		this.useReadDB = false;

--- a/lib/model.js
+++ b/lib/model.js
@@ -241,7 +241,7 @@ class Model {
 		return result;
 	}
 
-	async save(item) {
+	async save(item, setOnInsert) {
 
 		this.useReadDB = false;
 
@@ -254,7 +254,7 @@ class Model {
 		}
 
 		const db = await this.getDb();
-		const result = await db.save(this, item);
+		const result = await db.save(this, item, setOnInsert);
 
 		this._saveLog('upserted', item, result);
 
@@ -347,7 +347,7 @@ class Model {
 		return result;
 	}
 
-	async multiSave(items) {
+	async multiSave(items, setOnInsert) {
 
 		this.useReadDB = false;
 
@@ -374,7 +374,7 @@ class Model {
 		}
 
 		const db = await this.getDb();
-		const result = await db.multiSave(this, items);
+		const result = await db.multiSave(this, items, setOnInsert);
 
 		if(Array.isArray(items)) {
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -23,6 +23,13 @@ class Model {
 		return DEFAULT_PAGE_LIMIT;
 	}
 
+	static get statuses() {
+		return {
+			active: 'active',
+			inactive: 'inactive'
+		};
+	}
+
 	async getDb() {
 
 		if(this.databaseKey)

--- a/tests/model-test.js
+++ b/tests/model-test.js
@@ -654,7 +654,7 @@ describe('Model', () => {
 		sandbox.assert.calledWithExactly(DBDriver.getTotals, myCoreModel);
 	});
 
-	['insert', 'save', 'remove'].forEach(method => {
+	['insert', 'remove'].forEach(method => {
 
 		it(`should call DBDriver ${method} method passing the model and the item received`, async () => {
 
@@ -669,6 +669,18 @@ describe('Model', () => {
 		});
 	});
 
+	it('should call DBDriver save method passing the model and the item received', async () => {
+
+		await myCoreModel.save({ foo: 'bar' });
+
+		sandbox.assert.calledOnce(DatabaseDispatcher.getDatabaseByKey);
+		sandbox.assert.calledWithExactly(DatabaseDispatcher.getDatabaseByKey, 'core');
+
+		// for debug use: DBDriver[method].getCall(0).args
+		sandbox.assert.calledOnce(DBDriver.save);
+		sandbox.assert.calledWithExactly(DBDriver.save, myCoreModel, { foo: 'bar' }, undefined);
+	});
+
 	it('Should call DBDriver update method passing the model and the values and filter received', async () => {
 
 		await myCoreModel.update({ status: -1 }, { foo: 'bar' });
@@ -681,19 +693,28 @@ describe('Model', () => {
 		sandbox.assert.calledWithExactly(DBDriver.update, myCoreModel, { status: -1 }, { foo: 'bar' });
 	});
 
-	['multiInsert', 'multiSave'].forEach(method => {
+	it('should call DBDriver multiInsert method passing the model and the items received', async () => {
 
-		it(`should call DBDriver ${method} method passing the model and the items received`, async () => {
+		await myCoreModel.multiInsert([{ foo: 'bar' }, { foo2: 'bar2' }]);
 
-			await myCoreModel[method]([{ foo: 'bar' }, { foo2: 'bar2' }]);
+		sandbox.assert.calledOnce(DatabaseDispatcher.getDatabaseByKey);
+		sandbox.assert.calledWithExactly(DatabaseDispatcher.getDatabaseByKey, 'core');
 
-			sandbox.assert.calledOnce(DatabaseDispatcher.getDatabaseByKey);
-			sandbox.assert.calledWithExactly(DatabaseDispatcher.getDatabaseByKey, 'core');
+		// for debug use: DBDriver[method].getCall(0).args
+		sandbox.assert.calledOnce(DBDriver.multiInsert);
+		sandbox.assert.calledWithExactly(DBDriver.multiInsert, myCoreModel, [{ foo: 'bar' }, { foo2: 'bar2' }]);
+	});
 
-			// for debug use: DBDriver[method].getCall(0).args
-			sandbox.assert.calledOnce(DBDriver[method]);
-			sandbox.assert.calledWithExactly(DBDriver[method], myCoreModel, [{ foo: 'bar' }, { foo2: 'bar2' }]);
-		});
+	it('should call DBDriver multiSave method passing the model and the items received', async () => {
+
+		await myCoreModel.multiSave([{ foo: 'bar' }, { foo2: 'bar2' }]);
+
+		sandbox.assert.calledOnce(DatabaseDispatcher.getDatabaseByKey);
+		sandbox.assert.calledWithExactly(DatabaseDispatcher.getDatabaseByKey, 'core');
+
+		// for debug use: DBDriver[method].getCall(0).args
+		sandbox.assert.calledOnce(DBDriver.multiSave);
+		sandbox.assert.calledWithExactly(DBDriver.multiSave, myCoreModel, [{ foo: 'bar' }, { foo2: 'bar2' }], undefined);
 	});
 
 	it('Should call DBDriver multiRemove method passing the model and the filter received', async () => {
@@ -1047,7 +1068,19 @@ describe('Model', () => {
 				sandbox.assert.calledWithExactly(DBDriver.save, myClientModel, {
 					some: 'data',
 					userCreated
-				});
+				}, undefined);
+			});
+
+			it('Should add the setOnInsert when it is passed', async () => {
+
+				DBDriver.save.returns();
+
+				await myClientModel.save({ some: 'data' }, { status: 'active' });
+
+				sandbox.assert.calledWithExactly(DBDriver.save, myClientModel, {
+					some: 'data',
+					userCreated
+				}, { status: 'active' });
 			});
 
 			[
@@ -1066,7 +1099,7 @@ describe('Model', () => {
 						[idField]: 'some-id',
 						some: 'data',
 						userModified
-					});
+					}, undefined);
 				});
 			});
 
@@ -1149,7 +1182,19 @@ describe('Model', () => {
 				sandbox.assert.calledWithExactly(DBDriver.multiSave, myClientModel, [
 					{ some: 'data', userCreated },
 					{ other: 'data', userCreated }
-				]);
+				], undefined);
+			});
+
+			it('Should add setOnInsert when it is passed', async () => {
+
+				DBDriver.multiSave.returns();
+
+				await myClientModel.multiSave([{ some: 'data' }, { other: 'data' }], { quantity: 100 });
+
+				sandbox.assert.calledWithExactly(DBDriver.multiSave, myClientModel, [
+					{ some: 'data', userCreated },
+					{ other: 'data', userCreated }
+				], { quantity: 100 });
 			});
 
 			[
@@ -1167,7 +1212,7 @@ describe('Model', () => {
 					sandbox.assert.calledWithExactly(DBDriver.multiSave, myClientModel, [
 						{ [idField]: 'some-id', some: 'data', userModified },
 						{ [idField]: 'other-id', other: 'data', userModified }
-					]);
+					], undefined);
 				});
 			});
 

--- a/tests/model-test.js
+++ b/tests/model-test.js
@@ -87,6 +87,19 @@ describe('Model', () => {
 		sandbox.restore();
 	});
 
+	it('Should return the statuses', async () => {
+
+		assert.deepStrictEqual(ClientModel.statuses, {
+			active: 'active',
+			inactive: 'inactive'
+		});
+
+		assert.deepStrictEqual(CoreModel.statuses, {
+			active: 'active',
+			inactive: 'inactive'
+		});
+	});
+
 	describe('Database getters', () => {
 
 		it('Should reject when model haven\'t a client injected or databaseKey getter', async () => {


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-220
​
**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere realizar las siguientes modificaciones

* Modificar los métodos save() y multiSave() para aceptar un parámetro object setOnInsert, el mismo debe ser enviado directamente al método del Driver.

* Agregar el getter de status default con los siguientes estados.

```
{
  active: 'active',
  inactive: 'inactive'
}
```
* Crear un nuevo método `mapIdByReferenceId() `que realice lo siguiente

Debe recibir un array de `referenceId`.

Debe realizar un único get a la base de datos filtrando por los referenceId recibidos.

Debe devolver siempre un object con el siguiente formato

```
{
  'asd-123': '5e188fe59f45e4000773b594',
  'ksks-123123': '5e188fdf9f45e4000773b593',
  'jj-9494': '5e188fd39f45e4000773b591'
}
```
En caso de no encontrar el documento para ese `referenceId`, no se debe devolver en el object.
​
**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados