### PR TITLE
JCN-fix-async-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Logs for write methods not awaited causing some logs not to be successfully sent
+
 ## [3.6.2] - 2020-04-03
 ### Changed
 - Dependencies updated

--- a/lib/model.js
+++ b/lib/model.js
@@ -312,7 +312,7 @@ class Model {
 
 		const result = await db.increment(this, filters, incrementData, item);
 
-		await this._saveLog('incremented', result, result._id.toString());
+		await this._saveLog('incremented', result, result._id.toString()); // eslint-disable-line no-underscore-dangle
 
 		return result;
 	}

--- a/lib/model.js
+++ b/lib/model.js
@@ -250,7 +250,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.insert(this, item);
 
-		this._saveLog('inserted', item, result);
+		await this._saveLog('inserted', item, result);
 
 		return result;
 	}
@@ -270,7 +270,7 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.save(this, item, setOnInsert);
 
-		this._saveLog('upserted', item, result);
+		await this._saveLog('upserted', item, result);
 
 		return result;
 	}
@@ -286,7 +286,7 @@ class Model {
 		const result = await db.update(this, values, filter);
 
 		if(isObject(filter))
-			this._saveLog('updated', { values, filter }, filter.id);
+			await this._saveLog('updated', { values, filter }, filter.id);
 
 		return result;
 	}
@@ -312,7 +312,7 @@ class Model {
 
 		const result = await db.increment(this, filters, incrementData, item);
 
-		this._saveLog('incremented', result, result._id.toString());
+		await this._saveLog('incremented', result, result._id.toString());
 
 		return result;
 	}
@@ -325,7 +325,7 @@ class Model {
 		const result = await db.remove(this, item);
 
 		if(isObject(item))
-			this._saveLog('removed', item, item.id);
+			await this._saveLog('removed', item, item.id);
 
 		return result;
 	}
@@ -351,12 +351,8 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.multiInsert(this, items);
 
-		if(Array.isArray(items)) {
-
-			items.forEach(item => {
-				this._saveLog('inserted', item);
-			});
-		}
+		if(Array.isArray(items))
+			await Promise.all(items.map(item => this._saveLog('inserted', item)));
 
 		return result;
 	}
@@ -390,12 +386,8 @@ class Model {
 		const db = await this.getDb();
 		const result = await db.multiSave(this, items, setOnInsert);
 
-		if(Array.isArray(items)) {
-
-			items.forEach(item => {
-				this._saveLog('upserted', item, item.id);
-			});
-		}
+		if(Array.isArray(items))
+			await Promise.all(items.map(item => this._saveLog('upserted', item, item.id)));
 
 		return result;
 	}
@@ -408,7 +400,7 @@ class Model {
 		const result = await db.multiRemove(this, filter);
 
 		if(isObject(filter))
-			this._saveLog('removed', filter, filter.id);
+			await this._saveLog('removed', filter, filter.id);
 
 		return result;
 	}
@@ -460,7 +452,7 @@ class Model {
 		if(typeof entityId !== 'undefined')
 			builtLog.entityId = entityId;
 
-		Log.add(this.session.clientCode, builtLog);
+		return Log.add(this.session.clientCode, builtLog);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/model",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/model-test.js
+++ b/tests/model-test.js
@@ -66,7 +66,7 @@ describe('Model', () => {
 			.returns(DBDriver);
 
 		sandbox.stub(Log, 'add')
-			.returns();
+			.resolves();
 
 		myCoreModel.formatGet = () => { };
 


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**
- Agregarle `await` al metodo `Log.add` para que dejen de perderse logs cuando la ejecución termina antes de que el log pueda enviarse correctamente.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego el await al envio de logs