### PR TITLE
JCN 323 Soportar parámetros opcionales en el método update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 - `update` Method now supports optional parameters for the query.
 
 ## [5.4.1] - 2021-03-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `update` Method now supports optional parameters for the query.
 
 ## [5.4.1] - 2021-03-26
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # model
 
 ![Build Status](https://github.com/janis-commerce/model/workflows/Build%20Status/badge.svg)
@@ -26,7 +27,7 @@ class MyModel extends Model {
 
 👀 Either in Core or Client model the `databaseKey` connection settings structure is the same:
 
-:information_source: The `type` property is the only one used by this package to fetch the correct DB Driver package to use.  
+:information_source: The `type` property is the only one used by this package to fetch the correct DB Driver package to use.
 :warning: The rest of the connection properties depends entirely by the DB Driver that you will use.
 
 ```js
@@ -387,9 +388,12 @@ const items = await myModel.get({ filters: { foo: 'bar' }});
 ```
 </details>
 
-### async  `update(values, filter)`
+### async  `update(values, filter, params)`
 <details>
 	<summary>Update items that match with the <tt>filter</tt>.</summary>
+
+#### Parameters
+- `params` optional parameters to define some behavior of the query
 
 #### Example
 ```js
@@ -521,7 +525,7 @@ after:
 ```js
 const myItems = await myModel.get();
 
-/*  
+/*
 	[
 		{ some: 'item', otherProp: false },
 		{ some: 'otherItem', otherProp: true }
@@ -564,7 +568,7 @@ await myModel.dropDatabase();
 
 ---
 
-### :bookmark_tabs: Indexes Manipulation 
+### :bookmark_tabs: Indexes Manipulation
 ##### :warning: Only if DB Driver supports it
 
 ### async `getIndexes()`
@@ -693,11 +697,11 @@ It will be logged as:
 ```
 </details>
 
-## 🔑 Secrets 
-The package will get the **secret** using the `JANIS_SERVICE_NAME` environment variable.  
+## 🔑 Secrets
+The package will get the **secret** using the `JANIS_SERVICE_NAME` environment variable.
 If the **secret** is found, the result will be merged with the settings found in the *`janiscommercerc.json`* file or in the Client databases configuration. See [Database connection settings](#Database-connection-settings).
 
-The Secrets are stored in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager) and obtained with the package [@janiscommerce/aws-secrets-manager](https://www.npmjs.com/package/@janiscommerce/aws-secrets-manager) 
+The Secrets are stored in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager) and obtained with the package [@janiscommerce/aws-secrets-manager](https://www.npmjs.com/package/@janiscommerce/aws-secrets-manager)
 
 <details>
 	<summary>Complete example in which the settings are obtained for settings file or Client and merged with the fetched credentials in AWS Secrets Manager.</summary>

--- a/lib/model.js
+++ b/lib/model.js
@@ -443,8 +443,9 @@ class Model {
 	/**
 	 * @param {*} values Values to update
 	 * @param {Filters} filter Filters that define which records to update
+	 * @param {*} params Optional parameters to define some behavior of the query
 	 */
-	async update(values, filter) {
+	async update(values, filter, params) {
 
 		this.useReadDB = false;
 
@@ -454,10 +455,10 @@ class Model {
 		if(this.session && this.session.userId && isObject(values))
 			values.userModified = this.session.userId;
 
-		const result = await db.update(this, values, filter);
+		const result = await db.update(this, values, filter, params);
 
 		if(isObject(filter))
-			await this.logHelper.add('updated', { values, filter }, filter.id);
+			await this.logHelper.add('updated', { values, filter, params }, filter.id);
 
 		return result;
 	}

--- a/tests/model.js
+++ b/tests/model.js
@@ -551,7 +551,7 @@ describe('Model', () => {
 
 		await myCoreModel.update({ status: -1 }, { foo: 'bar' });
 
-		sandbox.assert.calledOnceWithExactly(DBDriver.prototype.update, myCoreModel, { status: -1 }, { foo: 'bar' });
+		sandbox.assert.calledOnceWithExactly(DBDriver.prototype.update, myCoreModel, { status: -1 }, { foo: 'bar' }, undefined);
 	});
 
 	it('should call DBDriver multiInsert method passing the model and the items received', async () => {
@@ -844,7 +844,7 @@ describe('Model', () => {
 				sandbox.assert.calledOnceWithExactly(DBDriver.prototype.update, myClientModel, {
 					some: 'data',
 					userModified
-				}, {});
+				}, {}, undefined);
 			});
 
 			it('Should log the update operation when session exists', async () => {
@@ -852,7 +852,7 @@ describe('Model', () => {
 				sandbox.stub(DBDriver.prototype, 'update')
 					.resolves(1);
 
-				await myClientModel.update({ some: 'data' }, { id: 'some-id' });
+				await myClientModel.update({ some: 'data' }, { id: 'some-id' }, { some: 'param' });
 
 				sandbox.assert.calledWithExactly(Log.add, 'some-client', {
 					type: 'updated',
@@ -861,7 +861,8 @@ describe('Model', () => {
 					userCreated,
 					log: {
 						values: { some: 'data', userModified },
-						filter: { id: 'some-id' }
+						filter: { id: 'some-id' },
+						params: { some: 'param' }
 					}
 				});
 			});


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-321

**SUB-TAREA**
https://fizzmod.atlassian.net/browse/JCN-323

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se requiere soportar la funcionalidad del **arrayFilters** en el método **update** del package de mongo.

Se debe agregar al método **update** del package model la posibilidad de recibir nuevo parámetros opcionales. 

**DESCRIPCIÓN DE LA SOLUCIÓN**
- Se modifico el método **update** para soportar los parámetros opcionales.
- Se modificaron los test.
- Se modifico el **README** y el **CHANGELOG**.