### PR TITLE
Jv2 78 custom logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Now can add custom data to log in any write operation
+
 ## [5.5.0] - 2021-04-13
 ### Changed
 - `update` Method now supports optional parameters for the query.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Now can add custom data to log in any write operation
 ## [5.5.0] - 2021-04-13
 ### Changed
 - `update` Method now supports optional parameters for the query.

--- a/README.md
+++ b/README.md
@@ -697,6 +697,62 @@ It will be logged as:
 ```
 </details>
 
+### :memo: Set custom log data
+<details>
+	<summary>You can add custom message or object data to log</summary>
+	<br>
+
+Adding a custom message:
+```js
+await myModel
+  .setLogData('custom message!')
+  .insert({ foo: 'bar' });
+
+/*
+	Log: {
+		...logData,
+		message: 'custom message!'
+	}
+*/
+```
+
+Adding a custom object data:	
+```js
+await myModel
+  .setLogData({message:'custom message!', type:'some type'})
+  .insert({ foo: 'bar' });
+
+/*
+	Log: {
+		...logData,
+		message: 'custom message!',
+		type:'some type'
+	}
+*/
+```
+
+Adding a custom object data with log property name:	
+```js
+await myModel
+  .setLogData({message:'custom message!', type:'some type', log: { isTest: true }})
+  .insert({ foo: 'bar' });
+
+/*
+	Log: {
+		...logData,
+		message: 'custom message!',
+		type:'some type',
+		log:{
+			...defaultModelLogData,
+			isTest: true
+		}
+	}
+*/
+```
+
+</details>
+
+
 ## 🔑 Secrets
 The package will get the **secret** using the `JANIS_SERVICE_NAME` environment variable.
 If the **secret** is found, the result will be merged with the settings found in the *`janiscommercerc.json`* file or in the Client databases configuration. See [Database connection settings](#Database-connection-settings).

--- a/lib/helpers/log.js
+++ b/lib/helpers/log.js
@@ -25,6 +25,7 @@ module.exports = class LogHelper {
 		this.modelName = modelNameSanitizer(params.modelName);
 		/** @private */
 		this.excludeFieldsInLog = Array.isArray(params.excludeFieldsInLog) ? params.excludeFieldsInLog : null;
+		this.customLogData = null;
 	}
 
 	/**
@@ -76,15 +77,20 @@ module.exports = class LogHelper {
 	 */
 	buildLog(log, type, entityId) {
 
+		const formattedLog = this.customLogData && this.customLogData.log ? { ...log, ...this.customLogData.log } : log;
+
 		const builtLog = {
 			entity: this.modelName,
 			type,
 			userCreated: this.session.userId,
-			log: this.excludeFieldsInLog ? omitRecursive(log, this.excludeFieldsInLog) : log
+			...this.customLogData ? this.customLogData : {},
+			log: this.excludeFieldsInLog ? omitRecursive(formattedLog, this.excludeFieldsInLog) : formattedLog
 		};
 
 		if(typeof entityId !== 'undefined')
 			builtLog.entityId = entityId;
+
+		this.customLogData = null;
 
 		return builtLog;
 	}

--- a/lib/model.js
+++ b/lib/model.js
@@ -409,9 +409,7 @@ class Model {
 
 		const result = await db.insert(this, item);
 
-		const dataToLog = this._getLogData(item);
-
-		await this.logHelper.add('inserted', dataToLog, result);
+		await this.logHelper.add('inserted', item, result);
 
 		return result;
 	}
@@ -436,9 +434,8 @@ class Model {
 		}
 
 		const result = await db.save(this, item, setOnInsert);
-		const dataToLog = this._getLogData(item);
 
-		await this.logHelper.add('upserted', dataToLog, result);
+		await this.logHelper.add('upserted', item, result);
 
 		return result;
 	}
@@ -460,11 +457,9 @@ class Model {
 
 		const result = await db.update(this, values, filter, params);
 
-		if(isObject(filter)) {
+		if(isObject(filter))
+			await this.logHelper.add('updated', { values, filter, params }, filter.id);
 
-			const dataToLog = this._getLogData({ values, filter, params });
-			await this.logHelper.add('updated', dataToLog, filter.id);
-		}
 		return result;
 	}
 
@@ -488,9 +483,7 @@ class Model {
 
 		const result = await db.increment(this, filters, incrementData, item);
 
-		const dataToLog = this._getLogData(result);
-
-		await this.logHelper.add('incremented', dataToLog, result._id.toString()); // eslint-disable-line no-underscore-dangle
+		await this.logHelper.add('incremented', result, result._id.toString()); // eslint-disable-line no-underscore-dangle
 
 		return result;
 	}
@@ -508,11 +501,8 @@ class Model {
 
 		const result = await db.remove(this, item);
 
-		if(isObject(item)) {
-
-			const dataToLog = this._getLogData(item);
-			await this.logHelper.add('removed', dataToLog, item.id);
-		}
+		if(isObject(item))
+			await this.logHelper.add('removed', item, item.id);
 
 		return result;
 	}
@@ -543,11 +533,8 @@ class Model {
 
 		const result = await db.multiInsert(this, items);
 
-		if(Array.isArray(items)) {
-
-			const logData = this._getLogData(items);
-			await this.logHelper.addByItem('inserted', logData);
-		}
+		if(Array.isArray(items))
+			await this.logHelper.addByItem('inserted', items);
 
 		return result;
 	}
@@ -587,12 +574,8 @@ class Model {
 
 		const result = await db.multiSave(this, items, setOnInsert);
 
-		if(Array.isArray(items)) {
-
-			const logData = this._getLogData(items);
-
-			await this.logHelper.addByItem('upserted', logData);
-		}
+		if(Array.isArray(items))
+			await this.logHelper.addByItem('upserted', items);
 
 		return result;
 	}
@@ -609,11 +592,8 @@ class Model {
 
 		const result = await db.multiRemove(this, filter);
 
-		if(isObject(filter)) {
-
-			const dataToLog = this._getLogData(filter);
-			await this.logHelper.add('removed', dataToLog, filter.id);
-		}
+		if(isObject(filter))
+			await this.logHelper.add('removed', filter, filter.id);
 
 		return result;
 	}
@@ -657,40 +637,14 @@ class Model {
 		if(typeof logMessageOrData !== 'string' && !isObject(logMessageOrData))
 			throw new Error('The custom data to log must be string or an object');
 
-		this.logData = {
+		if(isObject(logMessageOrData) && logMessageOrData.log && !isObject(logMessageOrData.log))
+			throw new Error('The property name log in custom log data must be an object');
+
+		this.logHelper.customLogData = {
 			...typeof logMessageOrData === 'string' ? { message: logMessageOrData } : logMessageOrData
 		};
 
 		return this;
-	}
-
-	/**
-	 * Get the data to log
-	 *
-	 * @param {Array<*>|Object} data data to log
-	 * @returns {Array<*>|Object} formatted data to log
-	 */
-	_getLogData(data) {
-
-		if(!this.logData)
-			return data;
-
-		if(Array.isArray(data)) {
-
-			const formattedData = data.map(item => ({ ...item, ...this.logData }));
-			this.logData = null;
-
-			return formattedData;
-		}
-
-		data = {
-			...data,
-			...this.logData
-		};
-
-		this.logData = null;
-
-		return data;
 	}
 }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -409,7 +409,9 @@ class Model {
 
 		const result = await db.insert(this, item);
 
-		await this.logHelper.add('inserted', item, result);
+		const dataToLog = this._getLogData(item);
+
+		await this.logHelper.add('inserted', dataToLog, result);
 
 		return result;
 	}
@@ -434,8 +436,9 @@ class Model {
 		}
 
 		const result = await db.save(this, item, setOnInsert);
+		const dataToLog = this._getLogData(item);
 
-		await this.logHelper.add('upserted', item, result);
+		await this.logHelper.add('upserted', dataToLog, result);
 
 		return result;
 	}
@@ -457,9 +460,11 @@ class Model {
 
 		const result = await db.update(this, values, filter, params);
 
-		if(isObject(filter))
-			await this.logHelper.add('updated', { values, filter, params }, filter.id);
+		if(isObject(filter)) {
 
+			const dataToLog = this._getLogData({ values, filter, params });
+			await this.logHelper.add('updated', dataToLog, filter.id);
+		}
 		return result;
 	}
 
@@ -483,10 +488,13 @@ class Model {
 
 		const result = await db.increment(this, filters, incrementData, item);
 
-		await this.logHelper.add('incremented', result, result._id.toString()); // eslint-disable-line no-underscore-dangle
+		const dataToLog = this._getLogData(result);
+
+		await this.logHelper.add('incremented', dataToLog, result._id.toString()); // eslint-disable-line no-underscore-dangle
 
 		return result;
 	}
+
 
 	/**
 	 * @param {*} item An item with a unique identifier
@@ -500,8 +508,11 @@ class Model {
 
 		const result = await db.remove(this, item);
 
-		if(isObject(item))
-			await this.logHelper.add('removed', item, item.id);
+		if(isObject(item)) {
+
+			const dataToLog = this._getLogData(item);
+			await this.logHelper.add('removed', dataToLog, item.id);
+		}
 
 		return result;
 	}
@@ -532,8 +543,11 @@ class Model {
 
 		const result = await db.multiInsert(this, items);
 
-		if(Array.isArray(items))
-			await this.logHelper.addByItem('inserted', items);
+		if(Array.isArray(items)) {
+
+			const logData = this._getLogData(items);
+			await this.logHelper.addByItem('inserted', logData);
+		}
 
 		return result;
 	}
@@ -573,8 +587,12 @@ class Model {
 
 		const result = await db.multiSave(this, items, setOnInsert);
 
-		if(Array.isArray(items))
-			await this.logHelper.addByItem('upserted', items);
+		if(Array.isArray(items)) {
+
+			const logData = this._getLogData(items);
+
+			await this.logHelper.addByItem('upserted', logData);
+		}
 
 		return result;
 	}
@@ -591,8 +609,11 @@ class Model {
 
 		const result = await db.multiRemove(this, filter);
 
-		if(isObject(filter))
-			await this.logHelper.add('removed', filter, filter.id);
+		if(isObject(filter)) {
+
+			const dataToLog = this._getLogData(filter);
+			await this.logHelper.add('removed', dataToLog, filter.id);
+		}
 
 		return result;
 	}
@@ -624,6 +645,52 @@ class Model {
 				newItems[item[newKey]] = item;
 			return newItems;
 		}, {});
+	}
+
+	/**
+	 * Set custom data to log
+	 *
+	 * @param {string|Object} logMessageOrData data to log
+	 */
+	setLogData(logMessageOrData) {
+
+		if(typeof logMessageOrData !== 'string' && !isObject(logMessageOrData))
+			throw new Error('The custom data to log must be string or an object');
+
+		this.logData = {
+			...typeof logMessageOrData === 'string' ? { message: logMessageOrData } : logMessageOrData
+		};
+
+		return this;
+	}
+
+	/**
+	 * Get the data to log
+	 *
+	 * @param {Array<*>|Object} data data to log
+	 * @returns {Array<*>|Object} formatted data to log
+	 */
+	_getLogData(data) {
+
+		if(!this.logData)
+			return data;
+
+		if(Array.isArray(data)) {
+
+			const formattedData = data.map(item => ({ ...item, ...this.logData }));
+			this.logData = null;
+
+			return formattedData;
+		}
+
+		data = {
+			...data,
+			...this.logData
+		};
+
+		this.logData = null;
+
+		return data;
 	}
 }
 


### PR DESCRIPTION
LINK AL TICKET
https://fizzmod.atlassian.net/browse/JV2-76

SUB-TAREA
https://fizzmod.atlassian.net/browse/JV2-78

DESCRIPCIÓN DEL REQUERIMIENTO

- Se debe crear un nuevo metodo chainable setLogData(logMessageOrData), donde logMessageOrData debe poder aceptar dos valores:

    - `string` Representando el campo message de los logs
    - `object` Que debe ser mergeado con el objeto del log a guardar.

- Este metodo debe guardar la informacion para incluirla en el proximo log que se genere con los metodos que escriben en la DB (insert, save, update, increment, multiInsert, multiSave)

- Una vez que se usa, se debe limpiar para evitar que se guarde en un segundo llamado a los metodos de escritura

- Se deben documentar los tipos correctamente

- Se debe actualizar la documentación del README

 

Ejemplos de uso:
```js
// 1: Si se pasa un string,
// tiene que guardar el log como hasta ahora, pero con el message 'Dale River!'
await myModel
  .setLogData('Dale River!')
  .insert({ foo: 'bar' });
/**
 * Log: {
 * 	...igualQueHastaAhora,
 * 	message: 'Dale River!'
 * }
 */

// 2: Si se pasa un objeto,
// se tienen que sobreescribir las propiedades pasadas en el log
await myModel
  .setLogData({
	type: 'cero-abandonos',
	message: 'Dale River!'
  })
  .insert({ foo: 'bar' }, );
/**
 * Log: {
 * 	...igualQueHastaAhora,
 * 	type: 'cero-abandonos',
 * 	message: 'Dale River!'
 * }
 */

// 3: Si se pasa un objeto que contiene la prop `log`,
// se tiene que mergear con el contenido que genera automaticamente Model
await myModel
  .setLogData({
	type: 'cero-abandonos',
	message: 'Dale River!',
	log: {
		colors: ['blanco', 'rojo']
	}
  })
  .insert({ foo: 'bar' });
/**
 * Log: {
 * 	...igualQueHastaAhora,
 * 	type: 'cero-abandonos',
 * 	message: 'Dale River!',
 * 	log: {
 * 		...defaultDeModel,
 * 		colors: ['blanco', 'rojo']
 * 	}
 * }
 */
 
// 4: Luego de llamar a un metodo de escritura, debe limpiar el `logData`
await myModel
  .setLogData('Dale River!')
  .insert({ foo: 'bar' });

await myModel.update({ foo: 'baz' }, { id });

/**
 * Log 1: {
 * 	...igualQueHastaAhora,
 * 	message: 'Dale River!'
 * }
 *
 * Log 2: {
 * 	...igualQueHastaAhora
 * }
 */
```

DESCRIPCIÓN DE LA SOLUCIÓN
- se agrego el metodo requerido en model
- se ajusto el helper `LogHelper` para dar soporte al nuevo formateo de los mismos
- se actualizo el README 