### PR TITLE
JCN - quick - FIX - Usar get con changekey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- When use `changeKeys` param and cannot get any items, it will return an empty object (before returns an empty array)
+
 ## [5.6.3] - 2021-08-09
 ### Fixed
 - Fixed DB connections cache for configs from AWS Secrets Manager

--- a/lib/model.js
+++ b/lib/model.js
@@ -286,8 +286,9 @@ class Model {
 
 		if(wasObject)
 			items = [items];
+
 		else if(!items.length)
-			return [];
+			return params.changeKeys ? {} : [];
 
 		const indexes = {};
 		const ids = [];

--- a/tests/model.js
+++ b/tests/model.js
@@ -618,6 +618,21 @@ describe('Model', () => {
 
 			assert.deepStrictEqual(result, {});
 		});
+
+		it('Should return empty object when items cannot be found', async () => {
+
+			sandbox.stub(DBDriver.prototype, 'get')
+				.resolves([]);
+
+			const result = await myCoreModel.get({
+				changeKeys: 'id'
+			});
+
+			sandbox.assert.calledOnceWithExactly(DBDriver.prototype.get, myCoreModel, { changeKeys: 'id' });
+			sandbox.assert.notCalled(Model.changeKeys);
+
+			assert.deepStrictEqual(result, {});
+		});
 	});
 
 	it('Should call method \'formatGet\' with each item', async () => {


### PR DESCRIPTION
LINK AL TICKET
-

DESCRIPCIÓN DEL REQUERIMIENTO
Cuando uno hace un `model.get({ changeKeys: 'id' })` y no se encuentra ningún item, sucede que devuelve un array vacio, el problema es que uno al usar el `changeKeys` esperaría un object.

Esto hace que la validación para estos cosas se vuelve "rara", es decir valida que sea un array. Esto no solo no es coherente con el comportamiento esperado sino que puede generar confunsión.

DESCRIPCIÓN DE LA SOLUCIÓN
Se desarrollaron los requerimientos solicitados 