### PR TITLE
JCN-368 Added support for multiple items update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
 	},
 
 	parserOptions: {
-		sourceType: 'script'
+		sourceType: 'script',
+		ecmaVersion: 2020
 	},
 
 	settings: {
@@ -55,9 +56,9 @@ module.exports = {
 		'func-names': 0,
 
 		'space-before-function-paren': ['error', {
-			'anonymous': 'never',
-			'named': 'never',
-			'asyncArrow': 'always'
+			anonymous: 'never',
+			named: 'never',
+			asyncArrow: 'always'
 		}],
 
 		'arrow-parens': ['error', 'as-needed'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support multiple data `update`
 ## [6.0.0] - 2021-11-01
 ### Fixed
 - When use `changeKeys` param and cannot get any items, it will return an empty object (before returns an empty array)

--- a/lib/model.js
+++ b/lib/model.js
@@ -453,8 +453,11 @@ class Model {
 		const db = await this.getDb();
 		this.validateMethodImplemented(db, 'update');
 
-		if(this.session && this.session.userId && isObject(values))
+		if(this.session?.userId && isObject(values))
 			values.userModified = this.session.userId;
+
+		else if(this.session?.userId && Array.isArray(values))
+			values.push({ userModified: this.session.userId });
 
 		const result = await db.update(this, values, filter, params);
 

--- a/tests/model.js
+++ b/tests/model.js
@@ -939,7 +939,7 @@ describe('Model', () => {
 
 		describe('update()', () => {
 
-			it('Should add the userModified field when session exists', async () => {
+			it('Should add the userModified field when session exists (data is object)', async () => {
 
 				sandbox.stub(DBDriver.prototype, 'update')
 					.resolves();
@@ -950,6 +950,20 @@ describe('Model', () => {
 					some: 'data',
 					userModified
 				}, {}, undefined);
+			});
+
+			it('Should add the userModified field when session exists (data is array)', async () => {
+
+				sandbox.stub(DBDriver.prototype, 'update')
+					.resolves();
+
+				await myClientModel.update([{ some: 'data' }, { name: 'Johnsson' }], {});
+
+				sandbox.assert.calledOnceWithExactly(DBDriver.prototype.update, myClientModel, [
+					{ some: 'data' },
+					{ name: 'Johnsson' },
+					{ userModified }
+				], {}, undefined);
 			});
 
 			it('Should log the update operation when session exists', async () => {


### PR DESCRIPTION
**LINK AL TICKET**
[Subtarea](https://fizzmod.atlassian.net/browse/JCN-368)

**DESCRIPCIÓN DEL REQUERIMIENTO**
El package de [Model](https://github.com/janis-commerce/model) necesita que al actualizar sepa como incluir el userModified cuando se actualiza con multiples datos.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados