### PR TITLE
JCN-375 Agregar soporte aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `aggregate` method
 
 ## [6.1.0] - 2022-03-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ const items = await myModel.get({ filters: { status: 2 }});
 
 ### async  `increment(filters, incrementData)`
 <details>
-	<summary>Increment/decrement values from an item in DB. This method will not perfrom an upsert.</summary>
+	<summary>Increment/decrement values from an item in DB. This method will not perform an upset.</summary>
 
 #### Example
 ```js
@@ -577,6 +577,33 @@ const myItems = await myModel.get({ filters: { status: 'active' }, changeKeys: '
 #### Example
 ```js
 await myModel.dropDatabase();
+```
+</details>
+
+### async  `aggregate(stages)`
+<details>
+	<summary>Execute Aggregation operations to obtain computed results in Mongodb Databases</summary>
+
+#### Parameters
+- `stages` An array with the aggregation stages
+
+#### Example
+```js
+
+const results = await myModel.aggregate([
+	{ $match: { id: '0000000055f2255a1a8e0c54' } }, // find the document with that id
+	{ $unset: 'category' }, // Removes the category field
+]);
+
+/**
+	[
+		{
+			id: '0000000055f2255a1a8e0c54',
+			name: 'Product 1',
+			description: 'Product 1 description'
+		}
+	]
+*/
 ```
 </details>
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -613,6 +613,20 @@ class Model {
 	}
 
 	/**
+	 * Use aggregates operations to obtain a computed result. Can only be used with MongoDB driver
+	 * @async
+	 * @param {object[]} stages A list of stages to be executed
+	 * @returns {Promise<object[]>} The result of the operations
+	 */
+	async aggregate(stages) {
+
+		const db = await this.getDb();
+		this.validateMethodImplemented(db, 'aggregate');
+
+		return db.aggregate(this, stages);
+	}
+
+	/**
 	 * Change keys
 	 *
 	 * @param {Array<Entity>} items The items

--- a/tests/model.js
+++ b/tests/model.js
@@ -1554,4 +1554,55 @@ describe('Model', () => {
 		});
 	});
 
+	describe('aggregate()', () => {
+
+		const itemId = '5df0151dbc1d570011949d87';
+
+		const stages = [
+			{ $match: { id: itemId, referenceId: 'display-id' } },
+			{ $unset: 'category' }
+		];
+
+		const results = [{
+			id: itemId,
+			name: 'Some name',
+			referenceId: 'display-id'
+		}];
+
+		it('Should failed if Driver has not aggregate function', async () => {
+
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
+
+			await assert.rejects(myClientModel.aggregate(stages));
+		});
+
+		it('Should resolves the aggregation stages', async () => {
+
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
+
+			const aggregate = sandbox.stub().resolves(results);
+
+			DBDriver.prototype.aggregate = aggregate;
+
+			assert.deepStrictEqual(await myClientModel.aggregate(stages), results);
+
+			sandbox.assert.calledOnceWithExactly(DBDriver.prototype.aggregate, myClientModel, stages);
+		});
+
+		it('Should failed if aggregates function rejects', async () => {
+
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
+
+			const aggregate = sandbox.stub().rejects();
+
+			DBDriver.prototype.aggregate = aggregate;
+
+			await assert.rejects(myClientModel.aggregate(stages));
+
+			sandbox.assert.calledOnceWithExactly(DBDriver.prototype.aggregate, myClientModel, stages);
+		});
+	});
 });


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-375

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se debe agregar el soporte para poder usar el nuevo método aggregate de Mongodb.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados