### PR TITLE
JCN 399 add id validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **getIdStruct** method to validate id type
 
 ## [6.2.0] - 2022-04-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -674,7 +674,7 @@ await myModel.dropIndexes(['name', 'code']);
 
 ### async  `getIdStruct()`
 <details>
-	<summary> Returns struct function to validate ID Type. This struct will vary according to the implemented DB by the model </summary>
+	<summary> Returns struct function to validate ID Type. This struct will vary depending on the implemented DB by the model </summary>
 
 #### Example (for mongodb DB)
 ```js

--- a/README.md
+++ b/README.md
@@ -671,6 +671,22 @@ await myModel.dropIndexes(['name', 'code']);
 ```
 </details>
 
+
+### async  `getIdStruct()`
+<details>
+	<summary> Returns struct function to validate ID Type. This struct will vary according to the implemented DB by the model </summary>
+
+#### Example (for mongodb DB)
+```js
+const idStruct = await myModel.getIdStruct();
+
+/*
+	struct('objectId')
+*/
+
+```
+
+</details>
 ---
 
 ## :clipboard: Logging

--- a/lib/model.js
+++ b/lib/model.js
@@ -669,6 +669,7 @@ class Model {
 	 * Returns a function to validate id.
 	 * ID type will vary depending on which database the model implements
 	 * @async
+	 * @returns {Function}
 	 */
 	async getIdStruct() {
 		const db = await this.getDb();

--- a/lib/model.js
+++ b/lib/model.js
@@ -664,6 +664,16 @@ class Model {
 
 		return this;
 	}
+
+	/**
+	 * Returns a function to validate id.
+	 * ID type will vary depending on which database the model implements
+	 * @async
+	 */
+	async getIdStruct() {
+		const db = await this.getDb();
+		return db.idStruct;
+	}
 }
 
 // Keep this separated to avoid breaking typings

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
     "sinon": "^11.1.2",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "@janiscommerce/superstruct": "^1.2.0"
   },
   "files": [
     "lib/",
@@ -42,7 +43,6 @@
     "@janiscommerce/aws-secrets-manager": "^0.2.0",
     "@janiscommerce/log": "^3.4.1",
     "@janiscommerce/settings": "^1.0.1",
-    "@janiscommerce/superstruct": "^1.2.0",
     "lodash.omit": "4.5.0",
     "md5": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@janiscommerce/aws-secrets-manager": "^0.2.0",
     "@janiscommerce/log": "^3.4.1",
     "@janiscommerce/settings": "^1.0.1",
+    "@janiscommerce/superstruct": "^1.2.0",
     "lodash.omit": "4.5.0",
     "md5": "^2.3.0"
   }

--- a/tests/db-driver.js
+++ b/tests/db-driver.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { struct } = require('@janiscommerce/superstruct');
+
 module.exports = class DBDriver {
 
 	constructor(config = {}) {
@@ -43,4 +45,8 @@ module.exports = class DBDriver {
 	dropIndexes() {}
 
 	dropDatabase() {}
+
+	get idStruct() {
+		return struct('objectId');
+	}
 };

--- a/tests/model.js
+++ b/tests/model.js
@@ -1609,7 +1609,7 @@ describe('Model', () => {
 
 	describe('idStruct()', () => {
 
-		it.only('Should return an idStruct function', async () => {
+		it('Should return an idStruct function', async () => {
 
 			const myClientModel = new ClientModel();
 			myClientModel.session = fakeSession;

--- a/tests/model.js
+++ b/tests/model.js
@@ -1609,12 +1609,13 @@ describe('Model', () => {
 
 	describe('idStruct()', () => {
 
-		it('Should return an idStruct function', async () => {
+		it.only('Should return an idStruct function', async () => {
 
-			const myModel = new OtherModel();
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
 
 			try {
-				await myModel.getIdStruct('123');
+				(await myClientModel.getIdStruct())('123');
 			} catch(error) {
 				assert.deepStrictEqual(error.message, 'Expected a value of type `objectId` but received `"123"`.');
 			}

--- a/tests/model.js
+++ b/tests/model.js
@@ -5,6 +5,7 @@ const mockRequire = require('mock-require');
 const sandbox = require('sinon');
 
 const Log = require('@janiscommerce/log');
+
 const Settings = require('@janiscommerce/settings');
 
 const { AwsSecretsManager } = require('@janiscommerce/aws-secrets-manager');
@@ -1603,6 +1604,20 @@ describe('Model', () => {
 			await assert.rejects(myClientModel.aggregate(stages));
 
 			sandbox.assert.calledOnceWithExactly(DBDriver.prototype.aggregate, myClientModel, stages);
+		});
+	});
+
+	describe('idStruct()', () => {
+
+		it('Should return an idStruct function', async () => {
+
+			const myModel = new OtherModel();
+
+			try {
+				await myModel.getIdStruct('123');
+			} catch(error) {
+				assert.deepStrictEqual(error.message, 'Expected a value of type `objectId` but received `"123"`.');
+			}
 		});
 	});
 });


### PR DESCRIPTION
[Historia](https://fizzmod.atlassian.net/browse/JCN-399)
[Subtarea](https://fizzmod.atlassian.net/browse/JCN-399)

Descripción del requerimiento
Se necesita que el package [GitHub - janis-commerce/model](https://github.com/janis-commerce/model) tenga un getter idStruct que sea un “pasamanos” del getter del mismo nombre del driver de la base de datos.  Ese desarrollo se encuentra [acá](https://fizzmod.atlassian.net/browse/JCN-398)

![image](https://user-images.githubusercontent.com/40437300/169896848-8b902095-161e-4dcd-bde6-a62a5d3d223a.png)
![image](https://user-images.githubusercontent.com/40437300/169897443-434ae588-893c-4544-84eb-0936eab3172f.png)

