### PR TITLE
JCN QUICK Skip idStruct in testing env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `idStruct` not execute in testing mode
 
 ## [6.5.1] - 2022-07-07
 ### Changed

--- a/lib/model.js
+++ b/lib/model.js
@@ -708,7 +708,7 @@ class Model {
 	 */
 	async getIdStruct() {
 
-		if(!process.env.JANIS_ENV || process.env.JANIS_ENV === 'local')
+		if(process.env.TEST_ENV === 'true' || !process.env.JANIS_ENV)
 			return;
 
 		const db = await this.getDb();

--- a/lib/model.js
+++ b/lib/model.js
@@ -707,6 +707,10 @@ class Model {
 	 * @returns {Function}
 	 */
 	async getIdStruct() {
+
+		if(!process.env.JANIS_ENV || process.env.JANIS_ENV === 'local')
+			return;
+
 		const db = await this.getDb();
 		return db.idStruct;
 	}

--- a/package.json
+++ b/package.json
@@ -20,15 +20,15 @@
   "license": "ISC",
   "homepage": "https://github.com/janis-commerce/model.git#readme",
   "devDependencies": {
-    "eslint": "^7.32.0",
+    "eslint": "^8.19.0",
     "eslint-config-airbnb-base": "^13.2.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-import": "^2.26.0",
     "husky": "^7.0.4",
-    "mocha": "^9.2.2",
+    "mocha": "^10.0.0",
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
-    "sinon": "^11.1.2",
-    "typescript": "^4.2.3",
+    "sinon": "^14.0.0",
+    "typescript": "^4.7.4",
     "@janiscommerce/superstruct": "^1.2.0"
   },
   "files": [
@@ -40,7 +40,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "@janiscommerce/aws-secrets-manager": "^0.2.0",
+    "@janiscommerce/aws-secrets-manager": "^0.2.1",
     "@janiscommerce/log": "^3.5.0",
     "@janiscommerce/settings": "^1.0.1",
     "lodash.omit": "4.5.0",

--- a/tests/model.js
+++ b/tests/model.js
@@ -1757,7 +1757,11 @@ describe('Model', () => {
 
 	describe('idStruct()', () => {
 
-		it('Should return an idStruct function', async () => {
+		it('Should return an idStruct function if environment is not local and database has idStruct', async () => {
+
+			const janisEnvToRestore = process.env.JANIS_ENV;
+
+			process.env.JANIS_ENV = 'beta';
 
 			const myClientModel = new ClientModel();
 			myClientModel.session = fakeSession;
@@ -1767,6 +1771,33 @@ describe('Model', () => {
 			} catch(error) {
 				assert.deepStrictEqual(error.message, 'Expected a value of type `objectId` but received `"123"`.');
 			}
+
+			process.env.JANIS_ENV = janisEnvToRestore;
+		});
+
+		it('Should return empty function if environment is not local and database has not idStruct', async () => {
+
+			const janisEnvToRestore = process.env.JANIS_ENV;
+
+			process.env.JANIS_ENV = 'beta';
+
+			assert.strictEqual(await otherModel.getIdStruct(), undefined);
+
+			process.env.JANIS_ENV = janisEnvToRestore;
+		});
+
+		it('Should return empty if environment is local', async () => {
+
+			const janisEnvToRestore = process.env.JANIS_ENV;
+
+			process.env.JANIS_ENV = 'local';
+
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
+
+			assert.strictEqual(await myClientModel.getIdStruct(), undefined);
+
+			process.env.JANIS_ENV = janisEnvToRestore;
 		});
 	});
 });

--- a/tests/model.js
+++ b/tests/model.js
@@ -1801,10 +1801,15 @@ describe('Model', () => {
 
 		it('Should return empty if environment is testing', async () => {
 
+			const janisEnvToRestore = process.env.JANIS_ENV;
+			process.env.JANIS_ENV = 'beta';
+
 			const myClientModel = new ClientModel();
 			myClientModel.session = fakeSession;
 
 			assert.strictEqual(await myClientModel.getIdStruct(), undefined);
+
+			process.env.JANIS_ENV = janisEnvToRestore;
 		});
 
 		it('Should return empty if environment is not set', async () => {

--- a/tests/model.js
+++ b/tests/model.js
@@ -1764,11 +1764,13 @@ describe('Model', () => {
 
 	describe('idStruct()', () => {
 
-		it('Should return an idStruct function if environment is not local and database has idStruct', async () => {
+		it('Should return an idStruct function if environment is not testing and database has idStruct', async () => {
 
 			const janisEnvToRestore = process.env.JANIS_ENV;
+			const testEnvToRestore = process.env.TEST_ENV;
 
 			process.env.JANIS_ENV = 'beta';
+			process.env.TEST_ENV = null;
 
 			const myClientModel = new ClientModel();
 			myClientModel.session = fakeSession;
@@ -1780,24 +1782,36 @@ describe('Model', () => {
 			}
 
 			process.env.JANIS_ENV = janisEnvToRestore;
+			process.env.TEST_ENV = testEnvToRestore;
 		});
 
-		it('Should return empty function if environment is not local and database has not idStruct', async () => {
+		it('Should return empty function if environment is not testing and database has not idStruct', async () => {
 
 			const janisEnvToRestore = process.env.JANIS_ENV;
+			const testEnvToRestore = process.env.TEST_ENV;
 
 			process.env.JANIS_ENV = 'beta';
+			process.env.TEST_ENV = null;
 
 			assert.strictEqual(await otherModel.getIdStruct(), undefined);
 
 			process.env.JANIS_ENV = janisEnvToRestore;
+			process.env.TEST_ENV = testEnvToRestore;
 		});
 
-		it('Should return empty if environment is local', async () => {
+		it('Should return empty if environment is testing', async () => {
+
+			const myClientModel = new ClientModel();
+			myClientModel.session = fakeSession;
+
+			assert.strictEqual(await myClientModel.getIdStruct(), undefined);
+		});
+
+		it('Should return empty if environment is not set', async () => {
 
 			const janisEnvToRestore = process.env.JANIS_ENV;
 
-			process.env.JANIS_ENV = 'local';
+			process.env.JANIS_ENV = null;
 
 			const myClientModel = new ClientModel();
 			myClientModel.session = fakeSession;


### PR DESCRIPTION
**LINK AL TICKET**
-

**DESCRIPCIÓN DEL REQUERIMIENTO**
El package genera problemas en los tests al intentar averiguar si hay struct para los ID en API-Get, esto debido a que se intenta gettear la base real para obtener este dato.

Se necesita que esto se evite de obtener este struct en los ambientes para Tests.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se desarrollaron los requerimientos solicitados