### PR TITLE
JCN-416-validate-empty-items-multiInsert-multiSave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `multiInsert()` and `multiSave()` empty items validation
 
 ## [6.8.1] - 2022-10-20
 ### Changed

--- a/lib/model.js
+++ b/lib/model.js
@@ -572,6 +572,9 @@ class Model {
 		if(!Array.isArray(items))
 			throw new ModelError('Items must be an Object Array to be inserted', ModelError.codes.INVALID_VALUE);
 
+		if(!items.length)
+			throw new ModelError('Items must not be empty to be inserted', ModelError.codes.INVALID_VALUE);
+
 		this.useReadDB = false;
 
 		const db = await this.getDb();
@@ -607,6 +610,9 @@ class Model {
 
 		if(!Array.isArray(items))
 			throw new ModelError('Items must be an Object Array to be saved', ModelError.codes.INVALID_VALUE);
+
+		if(!items.length)
+			throw new ModelError('Items must not be empty to be saved', ModelError.codes.INVALID_VALUE);
 
 		this.useReadDB = false;
 

--- a/tests/model.js
+++ b/tests/model.js
@@ -1586,6 +1586,13 @@ describe('Model', () => {
 				});
 			});
 
+			it('Should reject when calling multiInsert() if items array is empty', async () => {
+				await assert.rejects(myClientModel.multiInsert([]), {
+					code: ModelError.codes.INVALID_VALUE,
+					message: 'Items must not be empty to be inserted'
+				});
+			});
+
 			it('Should reject when calling multiSave() without an array', async () => {
 				await assert.rejects(myClientModel.multiSave({ field: 'value' }), {
 					code: ModelError.codes.INVALID_VALUE,
@@ -1597,6 +1604,13 @@ describe('Model', () => {
 				await assert.rejects(myClientModel.multiSave([{ field: 'value' }, 'invalid item']), {
 					code: ModelError.codes.INVALID_VALUE,
 					message: 'Each item to be saved must be an Object'
+				});
+			});
+
+			it('Should reject when calling multiSave() if items array is empty', async () => {
+				await assert.rejects(myClientModel.multiSave([]), {
+					code: ModelError.codes.INVALID_VALUE,
+					message: 'Items must not be empty to be saved'
 				});
 			});
 


### PR DESCRIPTION
**Links:**
[Historia](https://fizzmod.atlassian.net/browse/JCN-409) - [Subtarea](https://fizzmod.atlassian.net/browse/JCN-416)

**DESCRIPCIÓN DEL REQUERIMIENTO:**
Se requiere modificar el package [GitHub - janis-commerce/model](https://github.com/janis-commerce/model) para validar los métodos `multiSave()` y `multiInsert()`

Se debe validar que se reciba un Array con contenido porque hoy estamos mandando array vació `[]` al Driver :x:

**DESCRIPCIÓN DE LA SOLUCIÓN:**
- Se añadieron las validaciones que comprueban que no se manden arrays vacios en los métodos `multiSave()` y `multiInsert()`.
- Se añadieron tests para probar dicha funcionalidad.
- Se añadieron los cambios al CHANGELOG.md.