### PR TITLE
Add filters to getTotals method

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The default order when no order was received is field `id` using `asc` as order 
 	<summary>This method returns an object with data of totals. If filters is not present it will default to last <tt>get()</tt>  filters. If no <tt>get()</tt>  was executed before and no filters param is present, it will use no filters</summary>
 
 #### Parameters
-- `filters` is an optional.  Object with filters or array of filters. _Since 8.0.0_
+- `filters` is an optional.  Object with filters or array of filters. _Since 7.1.0_
 
 #### Result object structure:
 - **pages**: The total pages for the filters applied

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The default order when no order was received is field `id` using `asc` as order 
 	<summary>This method returns an object with data of totals. If filters is not present it will default to last <tt>get()</tt>  filters. If no <tt>get()</tt>  was executed before and no filters param is present, it will use no filters</summary>
 
 #### Parameters
-- `filters` is an optional.  Object with filters or array of filters. _Since 7.1.0_
+- `filters` is an optional.  Object with filters or array of filters. _Since 8.0.0_
 
 #### Result object structure:
 - **pages**: The total pages for the filters applied

--- a/README.md
+++ b/README.md
@@ -254,9 +254,13 @@ await myModel.getPaged({ filters: { status: 'active' } }, (items, page, limit) =
 #### Default order
 The default order when no order was received is field `id` using `asc` as order direction. _Since 6.8.3_
 
-### async  `getTotals()`
+### async  `getTotals(filters)`
+
 <details>
-	<summary>After performing a <tt>get()</tt> sometimes you need data of totals. This method returns an object with that information.</summary>
+	<summary>This method returns an object with data of totals. If filters is not present it will default to last <tt>get()</tt>  filters. If no <tt>get()</tt>  was executed before and no filters param is present, it will use no filters</summary>
+
+#### Parameters
+- `filters` is an optional.  Object with filters or array of filters. _Since 7.1.0_
 
 #### Result object structure:
 - **pages**: The total pages for the filters applied
@@ -278,6 +282,19 @@ const totals = await myModel.getTotals();
 	}
 */
 ```
+```js
+const totals = await myModel.getTotals( { status: 'active' } );
+/**
+	totals content:
+	{
+		pages: 3,
+		page: 1,
+		limit: 500,
+		total: 1450
+	}
+*/
+```
+
 </details>
 
 ### async  `mapIdBy(field, fieldValues, [params])`

--- a/lib/model.js
+++ b/lib/model.js
@@ -399,12 +399,12 @@ class Model {
 			await this.getPaged(newParams, callback);
 	}
 
-	async getTotals() {
+	async getTotals(filters) {
 
 		const db = await this.getDb();
 		this.validateMethodImplemented(db, 'getTotals');
 
-		return db.getTotals(this);
+		return db.getTotals(this, filters);
 	}
 
 	/**

--- a/tests/model.js
+++ b/tests/model.js
@@ -368,9 +368,9 @@ describe('Model', () => {
 				sinon.stub(DBDriver.prototype, 'getTotals')
 					.resolves();
 
-				await myCoreModel.getTotals({});
+				await myCoreModel.getTotals({ status: 'active' });
 
-				sinon.assert.calledOnceWithExactly(DBDriver.prototype.getTotals, myCoreModel, {});
+				sinon.assert.calledOnceWithExactly(DBDriver.prototype.getTotals, myCoreModel, { status: 'active' });
 			});
 		});
 

--- a/tests/model.js
+++ b/tests/model.js
@@ -363,14 +363,14 @@ describe('Model', () => {
 		});
 
 		describe('getTotals()', () => {
-			it('Should call DBDriver getTotals method passing the model', async () => {
+			it('Should call DBDriver getTotals method passing the model and filters', async () => {
 
 				sinon.stub(DBDriver.prototype, 'getTotals')
 					.resolves();
 
-				await myCoreModel.getTotals();
+				await myCoreModel.getTotals({});
 
-				sinon.assert.calledOnceWithExactly(DBDriver.prototype.getTotals, myCoreModel);
+				sinon.assert.calledOnceWithExactly(DBDriver.prototype.getTotals, myCoreModel, {});
 			});
 		});
 


### PR DESCRIPTION
### Link de la historia de usuario
https://janiscommerce.atlassian.net/browse/JCN-441

### Link de la/s sub-tareas
https://janiscommerce.atlassian.net/browse/JCN-446

### Descripción del requerimiento

Se necesita actualizar el package de [Model](https://github.com/janis-commerce/model/tree/master) para que el método getTotals pueda recibir un parametro de filters y a su vez este campo se lo pasé al driver encargado de hacer la query a la base de datos.

Esto va a servir para que el getTotals sepa calcular los totales segun filtros sin usarse el get con anterioridad

### Descripción de la solución

En model/lib/model/js modificar el metodo getTotals: incluir el param filter y pasarselo a db.getTotals(this, filter). 
Se debe en paralelo actualizar el metodo en JCN-442: Agregar filtros para getTotals en Mongodb

 
### Como probarlo

Ver https://github.com/janis-commerce/api-list/pull/18