### PR TITLE
Jcn 449 skip modified data

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ const items = await myModel.get({ filters: { foo: 'bar' }});
 
 #### Parameters
 - `params` optional parameters to define some behavior of the query
+	- `skipAutomaticSetModifiedData`: _Boolean_. When receive as **true**, the fields `dateModified` and `userModified` are not updated automatically.
 
 #### Example
 ```js

--- a/lib/model.js
+++ b/lib/model.js
@@ -510,10 +510,12 @@ class Model {
 		const db = await this.getDb();
 		this.validateMethodImplemented(db, 'update');
 
-		if(Array.isArray(values))
-			values.push(this.addModifiedData());
-		else
-			this.addModifiedData(values);
+		if(!params?.skipAutomaticSetModifiedData) {
+			if(Array.isArray(values))
+				values.push(this.addModifiedData());
+			else
+				this.addModifiedData(values);
+		}
 
 		this.setExecutionStart();
 

--- a/tests/model.js
+++ b/tests/model.js
@@ -1003,6 +1003,18 @@ describe('Model', () => {
 				}, {}, undefined);
 			});
 
+			it('Should skip the automatically field `dateModified` if the flag `skipAutomaticSetModifiedData` is setted', async () => {
+
+				sinon.stub(DBDriver.prototype, 'update')
+					.resolves();
+
+				await myClientModel.update({ some: 'data' }, {}, { skipAutomaticSetModifiedData: true });
+
+				sinon.assert.calledOnceWithExactly(DBDriver.prototype.update, myClientModel, {
+					some: 'data'
+				}, {}, { skipAutomaticSetModifiedData: true });
+			});
+
 			it('Should add the userModified field when session exists (data is array)', async () => {
 
 				sinon.stub(DBDriver.prototype, 'update')

--- a/tests/model.js
+++ b/tests/model.js
@@ -1003,7 +1003,7 @@ describe('Model', () => {
 				}, {}, undefined);
 			});
 
-			it('Should skip the automatically field `dateModified` if the flag `skipAutomaticSetModifiedData` is setted', async () => {
+			it('Should skip the automatically fields `dateModified` and `userModified` if the flag `skipAutomaticSetModifiedData` is setted', async () => {
 
 				sinon.stub(DBDriver.prototype, 'update')
 					.resolves();


### PR DESCRIPTION
Este es el primer ajuste que se requiere para poder omitir los datos automáticos al usar `update`, en este paquete afecta tanto a `dateModified` como a `userModified` se agrego una flag nueva para tener control sobre esto, y va de la mano con el package MongoDB, dado que sin importar lo que pase en model, este también suma `dateModified`.

El package ya paso por pruebas y fueron correctas comento el escenario que se uso para probar:
En OMS se hizo una lambda que actualiza dos datos puntuales a varios pedidos al mismo tiempo por medio de un filtro, para este ejemplo pongamos tres pedidos.
- Sin la flag ósea funcionamiento normal de siempre podemos darle al update 100 veces que siempre va actualizar los tres pedidos, esto pasa porque en todos los casos lo único que se termina actualizando son los dos campos automáticos nombrados anteriormente.
- Con flag y pedidos previamente actualizados, para este caso el resultado es siempre que la cantidad de documentos afectados es 0, con lo cual pasa a ser correcto y a que no se actualiza nada de forma automática
- Con flag y pedidos sin el dato nuevo, para este caso lo que se hizo fue a dos de los tres pedidos borrarles el dato que suma el `update` y con esto conseguir otro escenario, acá el resultado fue de dos documentos afectados.

Con lo cual el funcionamiento fue el esperado ya que para el que no use la flag sigue todo igual.