### PR TITLE
JCN-483- Agregar metodo multiUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,30 @@ const results = await myModel.aggregate([
 ```
 </details>
 
+### async  `multiUpdate(operations)`
+<details>
+	<summary>Perform a bulk save of update operations in DB. This action will update elements according to received filters.</summary>
+
+#### Example
+```js
+await myModel.multiUpdate([
+   { filter: { id: [1,2] }, data: { name: 'test 1' } },
+   { filter: { otherId: 3 }, data: { name: 'test 2' } }
+]);
+
+const items = await myModel.get();
+
+/**
+	items content:
+	[
+		{ id: 1, name: 'test 1' },
+		{ id: 4, otherId: 3, name: 'test 2' }
+	]
+*/
+```
+</details>
+
+
 ---
 
 ### :bookmark_tabs: Indexes Manipulation

--- a/lib/model.js
+++ b/lib/model.js
@@ -711,6 +711,22 @@ class Model {
 	}
 
 	/**
+	 * Use multiUpdate to update multiple documents with different filters and values. Can only be used with MongoDB driver
+	 * @async
+	 * @param {object[]} operations A list of db operations to be executed
+	 * @returns {Promise<object[]>} The result of the operations
+	 */
+	async multiUpdate(operations) {
+
+		const db = await this.getDb();
+		this.validateMethodImplemented(db, 'multiUpdate');
+
+		this.setExecutionStart();
+
+		await db.multiUpdate(this, operations);
+	}
+
+	/**
 	 * Change keys
 	 *
 	 * @param {Array<Entity>} items The items

--- a/lib/model.js
+++ b/lib/model.js
@@ -57,6 +57,19 @@ const DEFAULT_PAGE_LIMIT = 500;
  * @property {number} page The current page number
  */
 
+/**
+ * @typedef {object} UpdateOperation
+ * Describes the parameters for an update operation in database.
+ * This includes both the selection criteria and the new data to apply.
+ *
+ * @property {object} filter - The filter conditions used to select the documents to update.
+ * For example, { age: { $gt: 18 } } selects documents where the age field is greater than 18.
+ *
+ * @property {object} data - The new values for the selected documents properties.
+ * Each key-value pair represents a property to update and the new value to set.
+ * For example, { name: "John", age: 30 } sets the 'name' to "John" and 'age' to 30.
+ */
+
 class Model {
 
 	get databaseKey() {
@@ -713,17 +726,36 @@ class Model {
 	/**
 	 * Use multiUpdate to update multiple documents with different filters and values. Can only be used with MongoDB driver
 	 * @async
-	 * @param {object[]} operations A list of db operations to be executed
+	 * @param {UpdateOperation[]} operations A list of db operations to be executed
 	 * @returns {Promise<object[]>} The result of the operations
 	 */
 	async multiUpdate(operations) {
 
+		if(!Array.isArray(operations))
+			throw new ModelError('Operations must be an Object Array to be saved', ModelError.codes.INVALID_VALUE);
+
+		if(!operations.length)
+			throw new ModelError('Operations must not be empty to be saved', ModelError.codes.INVALID_VALUE);
+
+		this.useReadDB = false;
+
 		const db = await this.getDb();
 		this.validateMethodImplemented(db, 'multiUpdate');
 
+		operations = operations.map(operation => {
+
+			if(!isObject(operation))
+				throw new ModelError('Each operation to perform must be an Object', ModelError.codes.INVALID_VALUE);
+
+			// to standardize write methods (insert(), update(), save(), multiSave(), multiUpdate())
+			this.addModifiedData(operation.data);
+
+			return operation;
+		});
+
 		this.setExecutionStart();
 
-		await db.multiUpdate(this, operations);
+		return db.multiUpdate(this, operations);
 	}
 
 	/**

--- a/lib/model.js
+++ b/lib/model.js
@@ -742,15 +742,13 @@ class Model {
 		const db = await this.getDb();
 		this.validateMethodImplemented(db, 'multiUpdate');
 
-		operations = operations.map(operation => {
+		operations.forEach(operation => {
 
 			if(!isObject(operation))
 				throw new ModelError('Each operation to perform must be an Object', ModelError.codes.INVALID_VALUE);
 
 			// to standardize write methods (insert(), update(), save(), multiSave(), multiUpdate())
 			this.addModifiedData(operation.data);
-
-			return operation;
 		});
 
 		this.setExecutionStart();

--- a/tests/db-driver.js
+++ b/tests/db-driver.js
@@ -30,6 +30,8 @@ module.exports = class DBDriver {
 
 	multiRemove() {}
 
+	multiUpdate() {}
+
 	increment() {}
 
 	distinct() {}

--- a/tests/model-dispatch.js
+++ b/tests/model-dispatch.js
@@ -236,14 +236,14 @@ describe('Model Dispatch', () => {
 			await assertDbDriverConfig(myClientModel, client.databases.default.read);
 		});
 
+		const bulkMethods = ['multiInsert', 'multiSave', 'multiRemove', 'multiUpdate'];
+
 		[
 			'insert',
 			'update',
 			'save',
 			'remove',
-			'multiInsert',
-			'multiSave',
-			'multiRemove'
+			...bulkMethods
 		].forEach(method => {
 
 			it(`should call DBDriver using write DB when ${method} is executed after a readonly get`, async () => {
@@ -259,7 +259,7 @@ describe('Model Dispatch', () => {
 
 				await assertDbDriverConfig(myClientModel, client.databases.default.read);
 
-				if(['multiInsert', 'multiSave', 'multiRemove'].includes(method))
+				if(bulkMethods.includes(method))
 					await myClientModel[method]([{ foo: 'bar' }]);
 				else
 					await myClientModel[method]({ foo: 'bar' });


### PR DESCRIPTION
Link de la tarea

Epica: https://janiscommerce.atlassian.net/browse/JCN-480

Subtarea: https://janiscommerce.atlassian.net/browse/JCN-483

### Descripción del requerimiento
Actualmente nuestros paquetes de Mongo y Model no permiten realizar múltiples operaciones de actualización en una misma query a menos que exista un indice único (`multiSave`)

En este caso, en la tarea https://janiscommerce.atlassian.net/browse/JHUB-38   surge la necesidad de actualizar todos los skus de múltiples productos, lo cual hoy solo es posible de la siguiente manera:

- obteniendo todos los registros
- modificandolos desde codigo
- guardando con un multiSave

Esta misma operación podría hacerse con una sola query que contenga algo similar a esto

```
[{
	updateMany: {
		filter: { product: '123' },
		update: {
			$set: {
				brand: product1.brand
			}
		}
	}
},
{
	updateMany: {
		filter: { product: '456' },
		update: {
			$set: {
				brand: product2.brand,
				description: product2.description
			}
		}
	}
}]
```

## Solucion

Para permitir este tipo de operaciones se sumo en https://www.npmjs.com/package/@janiscommerce/mongodb  el nuevo método `multiUpdate` el cual recibirá los parámetros `model` y `operations`. Este ultimo parámetro sera el que se ejecutara con un bulkwrite

### Descripción de la solución | Análisis Funcional
- Se agrego el nuevo método `multiUpdate` para que llame a ese mismo metodo del driver de DB

### ¿Cómo se puede probar?
Dejo pruebas realizadas en local en playground:  https://www.loom.com/share/ea24653ff8bb48899bd385439b92ca21?sid=99b91e30-3ce3-47dd-96c2-2d672f7f420a

### CHANGELOG

```
### Changed
- Add *multiUpdate* method to update multiple documents with different filters and values.
```