### PR TITLE
update multiUpdate method and tests

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -744,11 +744,14 @@ class Model {
 
 		operations.forEach(operation => {
 
-			if(!isObject(operation))
-				throw new ModelError('Each operation to perform must be an Object', ModelError.codes.INVALID_VALUE);
+			if(!isObject(operation.data) && !Array.isArray(operation.data))
+				throw new ModelError('Values to update must be an Object or an Array', ModelError.codes.INVALID_VALUE);
 
 			// to standardize write methods (insert(), update(), save(), multiSave(), multiUpdate())
-			this.addModifiedData(operation.data);
+			if(Array.isArray(operation.data))
+				operation.data.push(this.addModifiedData());
+			else
+				this.addModifiedData(operation.data);
 		});
 
 		this.setExecutionStart();

--- a/tests/model-dispatch.js
+++ b/tests/model-dispatch.js
@@ -236,7 +236,7 @@ describe('Model Dispatch', () => {
 			await assertDbDriverConfig(myClientModel, client.databases.default.read);
 		});
 
-		const bulkMethods = ['multiInsert', 'multiSave', 'multiRemove', 'multiUpdate'];
+		const bulkMethods = ['multiInsert', 'multiSave', 'multiRemove'];
 
 		[
 			'insert',
@@ -266,6 +266,24 @@ describe('Model Dispatch', () => {
 
 				await assertDbDriverConfig(myClientModel, client.databases.default.write);
 			});
+		});
+
+		it('should call DBDriver using write DB when multiUpdate is executed after a readonly get', async () => {
+
+			stubGetSecret();
+
+			sinon.stub(DBDriver.prototype, 'multiUpdate')
+				.resolves();
+
+			const myClientModel = new ClientModel();
+
+			await myClientModel.get({ readonly: true });
+
+			await assertDbDriverConfig(myClientModel, client.databases.default.read);
+
+			await myClientModel.multiUpdate([{ data: { foo: 'bar' } }]);
+
+			await assertDbDriverConfig(myClientModel, client.databases.default.write);
 		});
 
 		it('should call DBDriver using write config DB when dropDatabase is executed', async () => {


### PR DESCRIPTION
[historia](https://janiscommerce.atlassian.net/browse/JCN-487)

[subtarea](https://janiscommerce.atlassian.net/browse/JCN-489)

## Descripcion del requerimiento:

Se requiere modificar el metodo multiUpdate para que acepte pipelines dentro de los valores a actualizar en cada operacion.
Para esto es necesario que acepte values de tipo Arrayy los procese como tales

Changelog:

# Changed
- MultiUpdate method now accepts operations with pipeline aggregations