### PR TITLE
JCN-514: Omit props from arrays in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,8 +920,8 @@ It will be logged as:
 ```
 
 ℹ️ **Note**:  
-- The wildcard `*` in the field path of the `excludeFieldsInLog` static getter, is used to access properties inside arrays.
-- The wildcard `**` in the field path of the `excludeFieldsInLog` static getter, is used to access the field in any level of the object.
+- The wildcard `*` in the field path of the `excludeFieldsInLog` static getter, is used to access properties inside arrays or when the root field path is unknown.
+- The wildcard `**` in the field path of the `excludeFieldsInLog` static getter, is used to access the field in any level of the object or when the intermediate field path is unknown between the root and the field to exclude.
 - The `excludeFieldsInLog` static getter can have both field names and field paths.
 
 ⚠️ **Warning**:  

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ class MyModel extends Model {
 			'password', // Exclude the password field
 			'**.address', // Exclude the address field in any nested object	of the log
 			'*.shipping.*.secondFactor', // Exclude the secondFactor field in any object in the shipping array without specifying the root object
-			'*.shipping.*.items.*.quantity' // Exclude the quantity field in any object in the items array of the shipping array without specifying the root object
+			'*.shipping.*.items.*.quantity' // Exclude the quantity field in any object in the items array of any object in the shipping array without specifying the root object
 		]
 	}
 }
@@ -919,7 +919,7 @@ It will be logged as:
 }
 ```
 
-IMPORTANT: 
+⚠️ **WARNING**:  
 - When using the wildcard `*` in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the path.
 - In case the field path is incorrect, it will not exclude any field.
 

--- a/README.md
+++ b/README.md
@@ -839,15 +839,16 @@ await myModel.insert({
 <details>
 	<summary>You can exclude fields for logs in case you have sensitive information in your entries such as passwords, addresses, etc.</summary>
 
-#### Specify the fields to exclude by setting them in the `static getter` `excludeFieldsInLog`:
+#### Specify the fields (as field name or field path) to exclude by setting them in the `static getter` `excludeFieldsInLog`:
 ```js
 class MyModel extends Model {
 
 	static get excludeFieldsInLog() {
 		return [
 			'password', // Exclude the password field
-			'**.address', // Exclude the address field in any nested object	
-			'*.shipping.*.secondFactor' // Exclude the secondFactor field in any object in the shipping array without specifying the root object
+			'**.address', // Exclude the address field in any nested object	of the log
+			'*.shipping.*.secondFactor', // Exclude the secondFactor field in any object in the shipping array without specifying the root object
+			'*.shipping.*.items.*.quantity' // Exclude the quantity field in any object in the items array of the shipping array without specifying the root object
 		]
 	}
 }
@@ -910,14 +911,18 @@ It will be logged as:
 			price: 10,
 			items: [
 				{
-					index: 0,
-					quantity: 1
+					index: 0
 				}
 			]
 		}
 	]
 }
 ```
+
+IMPORTANT: 
+- When using the wildcard `*` in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the path.
+- In case the field path is incorrect, it will not exclude any field.
+
 </details>
 
 ### :memo: Set custom log data

--- a/README.md
+++ b/README.md
@@ -925,7 +925,7 @@ It will be logged as:
 - The `excludeFieldsInLog` static getter can have both field names and field paths.
 
 ⚠️ **Warning**:  
-- When using the wildcard `*` in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the log.
+- When using the wildcard `*` alone in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the log.
 - In case the field path is incorrect, it will not exclude any field.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -919,8 +919,13 @@ It will be logged as:
 }
 ```
 
-⚠️ **WARNING**:  
-- When using the wildcard `*` in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the path.
+ℹ️ **Note**:  
+- The wildcard `*` in the field path of the `excludeFieldsInLog` static getter, is used to access properties inside arrays.
+- The wildcard `**` in the field path of the `excludeFieldsInLog` static getter, is used to access the field in any level of the object.
+- The `excludeFieldsInLog` static getter can have both field names and field paths.
+
+⚠️ **Warning**:  
+- When using the wildcard `*` in the field path of the `excludeFieldsInLog` static getter, it will exclude all the fields in the log.
 - In case the field path is incorrect, it will not exclude any field.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -845,9 +845,9 @@ class MyModel extends Model {
 
 	static get excludeFieldsInLog() {
 		return [
-			'password',
-			'address',
-			'secret'
+			'password', // Exclude the password field
+			'**.address', // Exclude the address field in any nested object	
+			'*.shipping.*.secondFactor' // Exclude the secondFactor field in any object in the shipping array without specifying the root object
 		]
 	}
 }
@@ -859,8 +859,33 @@ By setting this when you do an operation with an item like:
 await myModel.insert({
 	user: 'johndoe',
 	password: 'some-password',
-	country: 'AR',
-	address: 'Fake St 123'
+	location: {
+		country: 'some-country',
+		address: 'some-address'
+	},
+	shipping: [
+		{
+			addressCommerceId: 'some-address-commerce-id',
+			isPickup: false,
+			type: 'delivery',
+			deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+			deliveryWindow: {
+				initialDate: '2025-04-24T22:25:56.742Z',
+				finalDate: '2025-04-24T22:35:56.742Z'
+			},
+			price: 10,
+			items: [
+				{
+					index: 0,
+					quantity: 1
+				}
+			],
+			secondFactor: {
+				method: 'numericPin',
+				value: '1234'
+			}
+		}
+	]
 });
 
 ```
@@ -868,9 +893,29 @@ await myModel.insert({
 It will be logged as:
 ```js
 {
-	id: '5ea30bcbe28c55870324d9f0',
 	user: 'johndoe',
-	country: 'AR'
+	location: {
+		country: 'some-country'
+	},
+	shipping: [
+		{
+			addressCommerceId: 'some-address-commerce-id',
+			isPickup: false,
+			type: 'delivery',
+			deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+			deliveryWindow: {
+				initialDate: '2025-04-24T22:25:56.742Z',
+				finalDate: '2025-04-24T22:35:56.742Z'
+			},
+			price: 10,
+			items: [
+				{
+					index: 0,
+					quantity: 1
+				}
+			]
+		}
+	]
 }
 ```
 </details>

--- a/lib/helpers/log.js
+++ b/lib/helpers/log.js
@@ -32,6 +32,7 @@ module.exports = class LogHelper {
 
 		/** @private */
 		this.excludeFieldsInLog = Array.isArray(params.excludeFieldsInLog) ? params.excludeFieldsInLog : null;
+
 		this.customLogData = null;
 	}
 
@@ -145,7 +146,9 @@ module.exports = class LogHelper {
 			type,
 			userCreated: this.session.userId,
 			...this.customLogData ? this.customLogData : {},
-			log: this.excludeFieldsInLog ? omitRecursive(formattedLog, this.excludeFieldsInLog) : formattedLog
+			log: this.excludeFieldsInLog
+				? omitRecursive(formattedLog, this.excludeFieldsInLog)
+				: formattedLog
 		};
 
 		if(typeof entityId !== 'undefined')

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -3,10 +3,87 @@
 const cloneDeep = require('lodash.clonedeep');
 
 /**
+ * Checks if a given property path matches a specific pattern.
+ *
+ * @param {string[]} path - The current property path segments.
+ * @param {string[]} pattern - The pattern segments to match against.
+ * @param {number} i - Current index in the path array.
+ * @param {number} j - Current index in the pattern array.
+ * @returns {boolean} True if the path matches the pattern, false otherwise.
+ */
+const isPathMatch = (path, pattern, i = 0, j = 0) => {
+
+	// Special case: if pattern has only one segment, check if it matches the last path segment or is a wildcard
+	if(pattern.length === 1)
+		return path[path.length - 1] === pattern[0] || pattern[0] === '*';
+
+	// If all pattern segments are consumed, check if all path segments are also consumed
+	if(j === pattern.length)
+		return i === path.length;
+
+	// Handle double wildcard '**' which matches zero or more path segments
+	if(pattern[j] === '**') {
+
+		// Try matching the rest of the pattern starting from each possible position in the path
+		for(let k = i; k <= path.length; k++) {
+			// Recursively check if the remaining pattern matches from position k
+			if(isPathMatch(path, pattern, k, j + 1))
+				return true;
+		}
+
+		// If no match found with any position, return false
+		return false;
+	}
+
+	// If all path segments are consumed but still have pattern segments left, no match
+	if(i === path.length)
+		return false;
+
+	// If current pattern segment is not a wildcard and doesn't match current path segment, no match
+	if(pattern[j] !== '*' && pattern[j] !== path[i])
+		return false;
+
+	// Move to next segments in both path and pattern
+	return isPathMatch(path, pattern, i + 1, j + 1);
+};
+
+/**
+ * Recursively iterates over the object/array structure to find and remove matching properties.
+ *
+ * @param {string[]} patterns - The patterns as path segments of the properties to exclude when matching.
+ * @param {*} current - The current element being processed (object, array, or primitive).
+ * @param {string[]} currentPath - The path segments leading to the current element.
+ */
+const recurse = (patterns, current, currentPath = []) => {
+
+	// If current element is an array, recursively process each item with its index as path segment
+	if(Array.isArray(current))
+		current.forEach((item, index) => recurse(patterns, item, [...currentPath, String(index)]));
+	// If current element is an object (but not null), process its properties
+	else if(current && typeof current === 'object') {
+
+		// Iterate through all key-value pairs in the object
+		for(const [key, value] of Object.entries(current)) {
+
+			// Build the new path by adding the current key to the existing path
+			const newPath = [...currentPath, key];
+
+			// Check if the current path matches any of the exclusion patterns
+			if(patterns.some(p => isPathMatch(newPath, p)))
+				// If it matches, delete this property from the object
+				delete current[key];
+			else
+				// If it doesn't match, recursively process the value with the new path
+				recurse(patterns, value, newPath);
+		}
+	}
+};
+
+/**
  * Returns a new object excluding one or more properties recursively
  *
- * @param {object} object - The input object to process.
- * @param {string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', 'x.y']).
+ * @param {object} object - The input object to process that will be cloned and modified.
+ * @param {string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', '*.x.y', 'some-field']).
  * @returns {object} A new object with specified properties omitted.
  */
 const omitRecursive = (object, pathPatterns) => {
@@ -17,68 +94,10 @@ const omitRecursive = (object, pathPatterns) => {
 	// Deep clone the original object to avoid modifying it directly.
 	const clonedObject = cloneDeep(object);
 
-	/**
-	 * Checks if a given property path matches a specific pattern.
-	 *
-	 * @param {string[]} path - The current property path segments.
-	 * @param {string[]} pattern - The pattern segments to match against.
-	 * @param {number} i - Current index in the path array.
-	 * @param {number} j - Current index in the pattern array.
-	 * @returns {boolean} True if the path matches the pattern, false otherwise.
-	 */
-	function isPathMatch(path, pattern, i = 0, j = 0) {
+	// Recursive removal process from the root of the cloned object
+	recurse(patterns, clonedObject);
 
-		if(pattern.length === 1)
-			return path[path.length - 1] === pattern[0] || pattern[0] === '*';
-
-		if(j === pattern.length)
-			return i === path.length;
-
-		if(pattern[j] === '**') {
-
-			for(let k = i; k <= path.length; k++) {
-				if(isPathMatch(path, pattern, k, j + 1))
-					return true;
-			}
-
-			return false;
-		}
-
-		if(i === path.length)
-			return false;
-
-		if(pattern[j] !== '*' && pattern[j] !== path[i])
-			return false;
-
-		return isPathMatch(path, pattern, i + 1, j + 1);
-	}
-
-	/**
-	 * Recursively traverses the object/array structure to find and remove matching properties.
-	 *
-	 * @param {*} current - The current element being processed (object, array, or primitive).
-	 * @param {string[]} currentPath - The path segments leading to the current element.
-	 */
-	function recurse(current, currentPath = []) {
-
-		if(Array.isArray(current))
-			current.forEach((item, index) => recurse(item, [...currentPath, String(index)]));
-		else if(current && typeof current === 'object') {
-
-			for(const [key, value] of Object.entries(current)) {
-
-				const newPath = [...currentPath, key];
-
-				if(patterns.some(p => isPathMatch(newPath, p)))
-					delete current[key];
-				else
-					recurse(value, newPath);
-			}
-		}
-	}
-
-	recurse(clonedObject);
-
+	// Return the modified clone with specified properties removed
 	return clonedObject;
 };
 

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -1,33 +1,50 @@
 'use strict';
 
-const omit = require('lodash.omit');
-
 /**
  * Returns a new object excluding one or more properties recursively
  *
- * @param {Object<string, *>} object
- * @param {string|Array<string>} exclude
+ * @param {Object} object - The input object to process.
+ * @param {string|string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', 'x.y']).
+ * @returns {Object} A new object with specified properties omitted.
  */
-const omitRecursive = (object, exclude) => {
+const omitRecursive = (object, pathPatterns) => {
 
-	object = { ...object }; // Avoid original object modification
+	const patterns = pathPatterns.map(p => p.split('.'));
 
-	Object.entries(object).forEach(([key, value]) => {
+	const clonedObject = structuredClone(object); // Clones to avoid modifying the original object
 
-		/* istanbul ignore next */
-		if(Array.isArray(value)) {
-			object[key] = value.map(item => (typeof item === 'object' && item !== null
-				? omitRecursive(item, exclude)
-				: item)
-			);
-			return;
+	function isPathMatch(path, pattern) {
+
+		if(path.length !== pattern.length)
+			return false;
+
+		return path.every((part, i) => pattern[i] === '*' || pattern[i] === part);
+	}
+
+	function recurse(current, currentPath = []) {
+
+		if(Array.isArray(current)) {
+			current.forEach((item, index) => {
+				recurse(item, [...currentPath, String(index)]);
+			});
+		} else if(current && typeof current === 'object') {
+
+			for(const [key, value] of Object.entries(current)) {
+
+				const newPath = [...currentPath, key];
+
+				if(patterns.some(pattern => isPathMatch(newPath, pattern)))
+					delete current[key];
+				else
+					recurse(value, newPath);
+
+			}
 		}
+	}
 
-		if(value && typeof value === 'object' && !(value instanceof Date))
-			object[key] = omitRecursive(value, exclude);
-	});
+	recurse(clonedObject);
 
-	return omit(object, exclude);
+	return clonedObject;
 };
 
 /**

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -13,9 +13,18 @@ const omitRecursive = (object, exclude) => {
 	object = { ...object }; // Avoid original object modification
 
 	Object.entries(object).forEach(([key, value]) => {
-		object[key] = typeof value === 'object' && !Array.isArray(value) && !(value instanceof Date)
-			? omitRecursive(value, exclude)
-			: value;
+
+		/* istanbul ignore next */
+		if(Array.isArray(value)) {
+			object[key] = value.map(item => (typeof item === 'object' && item !== null
+				? omitRecursive(item, exclude)
+				: item)
+			);
+			return;
+		}
+
+		if(value && typeof value === 'object' && !(value instanceof Date))
+			object[key] = omitRecursive(value, exclude);
 	});
 
 	return omit(object, exclude);

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -18,25 +18,28 @@ const omitRecursive = (object, pathPatterns) => {
 		if(path.length !== pattern.length)
 			return false;
 
+		// Verify if every part of the path matches the pattern or pattern is a wildcard
 		return path.every((part, i) => pattern[i] === '*' || pattern[i] === part);
+
 	}
 
 	function recurse(current, currentPath = []) {
 
 		if(Array.isArray(current)) {
 			current.forEach((item, index) => {
-				recurse(item, [...currentPath, String(index)]);
+				recurse(item, [...currentPath, String(index)]); // Recursively process the item with updated path including index
+
 			});
 		} else if(current && typeof current === 'object') {
 
 			for(const [key, value] of Object.entries(current)) {
 
-				const newPath = [...currentPath, key];
+				const newPath = [...currentPath, key]; // Create new path by appending the current key
 
-				if(patterns.some(pattern => isPathMatch(newPath, pattern)))
-					delete current[key];
+				if(patterns.some(pattern => isPathMatch(newPath, pattern))) // Check if the new path matches any pattern
+					delete current[key]; // Delete the key if the path matches a pattern
 				else
-					recurse(value, newPath);
+					recurse(value, newPath); // Recursively process the value with the updated path
 
 			}
 		}

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -3,44 +3,74 @@
 /**
  * Returns a new object excluding one or more properties recursively
  *
- * @param {Object} object - The input object to process.
+ * @param {object} object - The input object to process.
  * @param {string|string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', 'x.y']).
- * @returns {Object} A new object with specified properties omitted.
+ * @returns {object} A new object with specified properties omitted.
  */
 const omitRecursive = (object, pathPatterns) => {
 
+	// Convert dot-notation path patterns into arrays of path segments.
 	const patterns = pathPatterns.map(p => p.split('.'));
 
-	const clonedObject = structuredClone(object); // Clones to avoid modifying the original object
+	// Deep clone the original object to avoid modifying it directly.
+	const clonedObject = structuredClone(object);
 
-	function isPathMatch(path, pattern) {
+	/**
+	 * Checks if a given property path matches a specific pattern.
+	 *
+	 * @param {string[]} path - The current property path segments.
+	 * @param {string[]} pattern - The pattern segments to match against.
+	 * @param {number} i - Current index in the path array.
+	 * @param {number} j - Current index in the pattern array.
+	 * @returns {boolean} True if the path matches the pattern, false otherwise.
+	 */
+	function isPathMatch(path, pattern, i = 0, j = 0) {
 
-		if(path.length !== pattern.length)
+		if(pattern.length === 1)
+			return path[path.length - 1] === pattern[0] || pattern[0] === '*';
+
+		if(j === pattern.length)
+			return i === path.length;
+
+		if(pattern[j] === '**') {
+
+			for(let k = i; k <= path.length; k++) {
+				if(isPathMatch(path, pattern, k, j + 1))
+					return true;
+			}
+
+			return false;
+		}
+
+		if(i === path.length)
 			return false;
 
-		// Verify if every part of the path matches the pattern or pattern is a wildcard
-		return path.every((part, i) => pattern[i] === '*' || pattern[i] === part);
+		if(pattern[j] !== '*' && pattern[j] !== path[i])
+			return false;
 
+		return isPathMatch(path, pattern, i + 1, j + 1);
 	}
 
+	/**
+	 * Recursively traverses the object/array structure to find and remove matching properties.
+	 *
+	 * @param {*} current - The current element being processed (object, array, or primitive).
+	 * @param {string[]} currentPath - The path segments leading to the current element.
+	 */
 	function recurse(current, currentPath = []) {
 
-		if(Array.isArray(current)) {
-			current.forEach((item, index) => {
-				recurse(item, [...currentPath, String(index)]); // Recursively process the item with updated path including index
-
-			});
-		} else if(current && typeof current === 'object') {
+		if(Array.isArray(current))
+			current.forEach((item, index) => recurse(item, [...currentPath, String(index)]));
+		else if(current && typeof current === 'object') {
 
 			for(const [key, value] of Object.entries(current)) {
 
-				const newPath = [...currentPath, key]; // Create new path by appending the current key
+				const newPath = [...currentPath, key];
 
-				if(patterns.some(pattern => isPathMatch(newPath, pattern))) // Check if the new path matches any pattern
-					delete current[key]; // Delete the key if the path matches a pattern
+				if(patterns.some(p => isPathMatch(newPath, p)))
+					delete current[key];
 				else
-					recurse(value, newPath); // Recursively process the value with the updated path
-
+					recurse(value, newPath);
 			}
 		}
 	}

--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const cloneDeep = require('lodash.clonedeep');
+
 /**
  * Returns a new object excluding one or more properties recursively
  *
  * @param {object} object - The input object to process.
- * @param {string|string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', 'x.y']).
+ * @param {string[]} pathPatterns - Property path(s) to exclude (e.g. ['a.b', 'x.y']).
  * @returns {object} A new object with specified properties omitted.
  */
 const omitRecursive = (object, pathPatterns) => {
@@ -13,7 +15,7 @@ const omitRecursive = (object, pathPatterns) => {
 	const patterns = pathPatterns.map(p => p.split('.'));
 
 	// Deep clone the original object to avoid modifying it directly.
-	const clonedObject = structuredClone(object);
+	const clonedObject = cloneDeep(object);
 
 	/**
 	 * Checks if a given property path matches a specific pattern.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@janiscommerce/log": "^5.1.0",
     "@janiscommerce/settings": "^1.0.1",
     "lllog": "^1.1.2",
-    "lodash.omit": "4.5.0",
+    "lodash.clonedeep": "^4.5.0",
     "md5": "^2.3.0"
   }
 }

--- a/tests/model.js
+++ b/tests/model.js
@@ -1766,7 +1766,7 @@ describe('Model', () => {
 			myClientModel.session = logSession;
 
 			ClientModel.excludeFieldsInLog = [
-				'item.password', 'item.location.address'
+				'password', '**.address'
 			];
 
 			sinon.stub(DBDriver.prototype, 'insert')
@@ -1808,7 +1808,7 @@ describe('Model', () => {
 
 			myClientModel.session = logSession;
 
-			ClientModel.excludeFieldsInLog = ['item.shipping.*.secondFactor'];
+			ClientModel.excludeFieldsInLog = ['*.shipping.*.secondFactor'];
 
 			sinon.stub(DBDriver.prototype, 'insert')
 				.resolves('62c45c01812a0a142d320ebd');

--- a/tests/model.js
+++ b/tests/model.js
@@ -1759,7 +1759,7 @@ describe('Model', () => {
 			userId: 'some-user-id'
 		};
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field is a string)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1796,6 +1796,89 @@ describe('Model', () => {
 						dateCreated: sinon.match.date,
 						userModified,
 						dateModified: sinon.match.date
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field is an array)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = ['secondFactor'];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							method: 'numericPin',
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0,
+										quantity: 1
+									}
+								]
+							}
+						]
 					},
 					executionTime: sinon.match.number
 				}

--- a/tests/model.js
+++ b/tests/model.js
@@ -1760,7 +1760,7 @@ describe('Model', () => {
 		};
 
 		// eslint-disable-next-line max-len
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where one is a field and the other one is a field path as string)', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when one is a field and the other one is a field path as string)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1803,7 +1803,7 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude one field from the log when excludeFieldsInLog static getter exists (where the field path is an array)', async () => {
+		it('Should exclude one field from the log when excludeFieldsInLog static getter exists (when the field path is an array)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1891,7 +1891,7 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude two or more fields from the log when excludeFieldsInLog static getter exists (where the field path is an array)', async () => {
+		it('Should exclude two or more fields from the log when excludeFieldsInLog static getter exists (when the field path is an array)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1981,7 +1981,7 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where the field path is a nested array)', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field path is a nested array)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -2072,7 +2072,98 @@ describe('Model', () => {
 		});
 
 		// eslint-disable-next-line max-len
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where one field path exists and the other one does not)', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the intermediate field path is unknown)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = ['item.**.quantity'];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0
+									}
+								],
+								secondFactor: {
+									value: '1234'
+								}
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		// eslint-disable-next-line max-len
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when one field path exists and the other one does not)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -2163,7 +2254,7 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude all the fields from the log when excludeFieldsInLog static getter exists (where the field path is a wildcard)', async () => {
+		it('Should exclude all the fields from the log when excludeFieldsInLog static getter exists (when the field path is a wildcard)', async () => {
 
 			const myClientModel = new ClientModel();
 

--- a/tests/model.js
+++ b/tests/model.js
@@ -1759,7 +1759,8 @@ describe('Model', () => {
 			userId: 'some-user-id'
 		};
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field in path is a string)', async () => {
+		// eslint-disable-next-line max-len
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where one is a field and the other one is a field path as string)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1802,7 +1803,7 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field path is an array)', async () => {
+		it('Should exclude one field from the log when excludeFieldsInLog static getter exists (where the field path is an array)', async () => {
 
 			const myClientModel = new ClientModel();
 
@@ -1820,7 +1821,6 @@ describe('Model', () => {
 					address: 'some-address'
 				},
 				secondFactor: {
-					method: 'numericPin',
 					value: '1234'
 				},
 				shipping: [
@@ -1841,7 +1841,6 @@ describe('Model', () => {
 							}
 						],
 						secondFactor: {
-							method: 'numericPin',
 							value: '1234'
 						}
 					}
@@ -1861,7 +1860,6 @@ describe('Model', () => {
 							address: 'some-address'
 						},
 						secondFactor: {
-							method: 'numericPin',
 							value: '1234'
 						},
 						userCreated,
@@ -1885,6 +1883,518 @@ describe('Model', () => {
 										quantity: 1
 									}
 								]
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		it('Should exclude two or more fields from the log when excludeFieldsInLog static getter exists (where the field path is an array)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = [
+				'*.shipping.*.secondFactor',
+				'*.shipping.*.addressCommerceId'
+			];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0,
+										quantity: 1
+									}
+								]
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where the field path is a nested array)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = ['*.shipping.*.items.*.quantity'];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0
+									}
+								],
+								secondFactor: {
+									value: '1234'
+								}
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		// eslint-disable-next-line max-len
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (where one field path exists and the other one does not)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = [
+				'*.shipping.*.secondFactor',
+				'*.shipping.*.deliveryWindows.initialDate'
+			];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0,
+										quantity: 1
+									}
+								]
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		it('Should exclude all the fields from the log when excludeFieldsInLog static getter exists (where the field path is a wildcard)', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = ['*'];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {}
+			}]);
+		});
+
+		it('Should not exclude the fields from the log when excludeFieldsInLog static getter exists but the field path does not exist', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = [
+				'',
+				'*.shipping.*.deliveryWindows.initialDate',
+				'.secondFactor.value',
+				'location.address.'
+			];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0,
+										quantity: 1
+									}
+								],
+								secondFactor: {
+									value: '1234'
+								}
+							}
+						]
+					},
+					executionTime: sinon.match.number
+				}
+			}]);
+		});
+
+		it('Should not exclude the fields from the log when excludeFieldsInLog static getter is an empty array', async () => {
+
+			const myClientModel = new ClientModel();
+
+			myClientModel.session = logSession;
+
+			ClientModel.excludeFieldsInLog = [];
+
+			sinon.stub(DBDriver.prototype, 'insert')
+				.resolves('62c45c01812a0a142d320ebd');
+
+			await myClientModel.insert({
+				username: 'some-username',
+				location: {
+					country: 'some-country',
+					address: 'some-address'
+				},
+				secondFactor: {
+					value: '1234'
+				},
+				shipping: [
+					{
+						addressCommerceId: 'some-address-commerce-id',
+						isPickup: false,
+						type: 'delivery',
+						deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+						deliveryWindow: {
+							initialDate: '2025-04-24T22:25:56.742Z',
+							finalDate: '2025-04-24T22:35:56.742Z'
+						},
+						price: 10,
+						items: [
+							{
+								index: 0,
+								quantity: 1
+							}
+						],
+						secondFactor: {
+							value: '1234'
+						}
+					}
+				]
+			});
+
+			sinon.assert.calledWithExactly(Log.add, 'some-client', [{
+				type: 'inserted',
+				entity: 'client',
+				entityId: '62c45c01812a0a142d320ebd',
+				userCreated,
+				log: {
+					item: {
+						username: 'some-username',
+						location: {
+							country: 'some-country',
+							address: 'some-address'
+						},
+						secondFactor: {
+							value: '1234'
+						},
+						userCreated,
+						dateCreated: sinon.match.date,
+						userModified,
+						dateModified: sinon.match.date,
+						shipping: [
+							{
+								addressCommerceId: 'some-address-commerce-id',
+								isPickup: false,
+								type: 'delivery',
+								deliveryEstimateDate: '2025-04-24T22:35:56.742Z',
+								deliveryWindow: {
+									initialDate: '2025-04-24T22:25:56.742Z',
+									finalDate: '2025-04-24T22:35:56.742Z'
+								},
+								price: 10,
+								items: [
+									{
+										index: 0,
+										quantity: 1
+									}
+								],
+								secondFactor: {
+									value: '1234'
+								}
 							}
 						]
 					},

--- a/tests/model.js
+++ b/tests/model.js
@@ -1759,14 +1759,14 @@ describe('Model', () => {
 			userId: 'some-user-id'
 		};
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field is a string)', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field in path is a string)', async () => {
 
 			const myClientModel = new ClientModel();
 
 			myClientModel.session = logSession;
 
 			ClientModel.excludeFieldsInLog = [
-				'password', 'address'
+				'item.password', 'item.location.address'
 			];
 
 			sinon.stub(DBDriver.prototype, 'insert')
@@ -1802,13 +1802,13 @@ describe('Model', () => {
 			}]);
 		});
 
-		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field is an array)', async () => {
+		it('Should exclude the fields from the log when excludeFieldsInLog static getter exists (when the field path is an array)', async () => {
 
 			const myClientModel = new ClientModel();
 
 			myClientModel.session = logSession;
 
-			ClientModel.excludeFieldsInLog = ['secondFactor'];
+			ClientModel.excludeFieldsInLog = ['item.shipping.*.secondFactor'];
 
 			sinon.stub(DBDriver.prototype, 'insert')
 				.resolves('62c45c01812a0a142d320ebd');
@@ -1818,6 +1818,10 @@ describe('Model', () => {
 				location: {
 					country: 'some-country',
 					address: 'some-address'
+				},
+				secondFactor: {
+					method: 'numericPin',
+					value: '1234'
 				},
 				shipping: [
 					{
@@ -1855,6 +1859,10 @@ describe('Model', () => {
 						location: {
 							country: 'some-country',
 							address: 'some-address'
+						},
+						secondFactor: {
+							method: 'numericPin',
+							value: '1234'
 						},
 						userCreated,
 						dateCreated: sinon.match.date,

--- a/tests/resources/props.js
+++ b/tests/resources/props.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const deleteProp = (object, prop) => {
+	const { [prop]: propToRemove, ...newObject } = object;
+	return newObject;
+};
+
+const deleteManyProps = (object, props) => {
+	return props.reduce((obj, prop) => deleteProp(obj, prop), { ...object });
+};
+
+module.exports = {
+	deleteProp,
+	deleteManyProps
+};


### PR DESCRIPTION
## Historia de usuario
https://janiscommerce.atlassian.net/browse/JCN-513

## Sub-tarea
https://janiscommerce.atlassian.net/browse/JCN-514

## Descripcion del requerimiento
Actualmente el paquete `@janiscommerce/model` no permite omitir de los logs propiedades que estan dentro de arrays. Por ende, se muestran dichas propiedades con informacion sensible de seguridad lo cual no es adecuado ni seguro.

Es necesario modificar el getter `excludeFieldsInLog` para que dichas propiedades puedan ser removidas de los logs en caso de ser especificado.

## Descripcion de la solucion
Al recibir el array `excludeFieldsInLog`, se llama a un metodo `omitRecursive` el cual fue modificado para lograr el requerimiento. Ahora, en vez de pasar solo nombres de propiedades, se puede hacer lo siguiente:
- Pasar un nombre de una propiedad (funciona igual que antes, la borra recursivamente de todo el log)
- Pasar un path especifico a una propiedad (borra la propiedad solo en ese path)

Para la opcion del path, en caso de no saber el nombre root del log (es decir, `item`, `values`, etc.), se puede usar una wildcard `*` y luego la propiedad a eliminar. Tambien, para los casos donde la propiedad esta dentro un array de objeto, se debe usar la wildcard `*` para que recorra cada objeto del array.

## Screenshots
![Screenshot from 2025-05-13 10-12-32](https://github.com/user-attachments/assets/f3c5eda9-72b5-4a8f-bc47-819f6e7c388f)
![Screenshot from 2025-05-13 10-07-17](https://github.com/user-attachments/assets/5f97711f-ac82-4c86-819c-d1304792a297)
![Screenshot from 2025-05-13 10-18-25](https://github.com/user-attachments/assets/f0d42bd8-3871-4592-9ab1-a8805d7b0061)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for omitting nested fields from logs using flexible path patterns, including array-based path formats.
- **Bug Fixes**
	- Improved handling of recursive property omission to support complex patterns and wildcards.
- **Tests**
	- Added extensive tests covering exclusion of nested fields with wildcards and multiple path patterns.
	- Introduced utility helpers for property removal and log assertion in tests.
- **Documentation**
	- Updated examples and explanations to demonstrate advanced field exclusion patterns and wildcard usage in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->