### PR TITLE
JCN-522: Refactor omitRecursive method to improve performance in logs to exclude

### DIFF
--- a/lib/helpers/utils.js
+++ b/lib/helpers/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const cloneDeep = require('lodash.clonedeep');
-
 /**
  * Checks if a given property path matches a specific pattern.
  *
@@ -57,24 +55,33 @@ const isPathMatch = (path, pattern, i = 0, j = 0) => {
 const recurse = (patterns, current, currentPath = []) => {
 
 	// If current element is an array, recursively process each item with its index as path segment
-	if(Array.isArray(current))
-		current.forEach((item, index) => recurse(patterns, item, [...currentPath, String(index)]));
-	// If current element is an object (but not null), process its properties
-	else if(current && typeof current === 'object') {
+	if(Array.isArray(current)) {
 
-		// Iterate through all key-value pairs in the object
-		for(const [key, value] of Object.entries(current)) {
+		// Iterate through all items in the array
+		for(const [index, item] of current.entries()) {
+			currentPath.push(String(index));
+			recurse(patterns, item, currentPath);
+			currentPath.pop();
+		}
 
-			// Build the new path by adding the current key to the existing path
-			const newPath = [...currentPath, key];
+	} else if(current && typeof current === 'object') {
+
+		// Iterate through all object keys
+		for(const key of Object.keys(current)) {
+
+			// Add the current key to the path
+			currentPath.push(key);
 
 			// Check if the current path matches any of the exclusion patterns
-			if(patterns.some(p => isPathMatch(newPath, p)))
+			if(patterns.some(p => isPathMatch(currentPath, p)))
 				// If it matches, delete this property from the object
 				delete current[key];
 			else
-				// If it doesn't match, recursively process the value with the new path
-				recurse(patterns, value, newPath);
+				// If it doesn't match, recursively process the value
+				recurse(patterns, current[key], currentPath);
+
+			// Remove the key from the path after processing
+			currentPath.pop();
 		}
 	}
 };
@@ -89,10 +96,13 @@ const recurse = (patterns, current, currentPath = []) => {
 const omitRecursive = (object, pathPatterns) => {
 
 	// Convert dot-notation path patterns into arrays of path segments.
-	const patterns = pathPatterns.map(p => p.split('.'));
+	const patterns = [];
+
+	for(const p of pathPatterns)
+		patterns.push(p.split('.'));
 
 	// Deep clone the original object to avoid modifying it directly.
-	const clonedObject = cloneDeep(object);
+	const clonedObject = structuredClone(object);
 
 	// Recursive removal process from the root of the cloned object
 	recurse(patterns, clonedObject);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@janiscommerce/log": "^5.1.1",
     "@janiscommerce/settings": "^1.0.1",
     "lllog": "^1.1.2",
-    "lodash.clonedeep": "^4.5.0",
     "md5": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "tests"
   },
   "dependencies": {
-    "@aws-sdk/client-ssm": "^3.835.0",
+    "@aws-sdk/client-ssm": "^3.859.0",
     "@janiscommerce/aws-secrets-manager": "^1.1.1",
     "@janiscommerce/log": "^5.1.1",
     "@janiscommerce/settings": "^1.0.1",


### PR DESCRIPTION
## Historia de usuario
https://janiscommerce.atlassian.net/browse/JCN-521

## Sub-tarea
https://janiscommerce.atlassian.net/browse/JCN-522

## Descripcion del requerimiento
Recientemente se actualizo este package Model y package API para poder ocultar propiedades en logs que estuvieron dentro de arrays. Para ello, se modifico la funcion `omitRecursive` para que acepte paths. Pero en API, se propusieron cambios en el PR ([historia asociada](https://janiscommerce.atlassian.net/browse/JCN-519)), que mejoraron los tiempos de performance. Por ende, es necesario aplicar los mismos a Model para mejorar la performance.

## Descripcion de la solucion
Se actualizo el metodo `omtiRecursive` y `recurse` para mejorar la performance al excluir logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance and reduced dependencies by replacing a third-party deep cloning library with a native solution for object cloning.
  * Enhanced efficiency of recursive property omission logic.

* **Chores**
  * Removed an external dependency from the application’s package list.
  * Updated AWS SDK dependency to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->